### PR TITLE
Add new userspace component for PoKeys

### DIFF
--- a/pokeys_userspace/pokeys_analog_io.comp
+++ b/pokeys_userspace/pokeys_analog_io.comp
@@ -34,6 +34,7 @@ void user_mainloop() {
     while (1) {
         for (int i = 0; i < 7; i++) {
             analog_out[i] = PK_SL_AnalogInputGet(device, i);
+            PK_SL_AnalogOutputSet(device, i, analog_in[i]);
         }
         usleep(10000);
     }

--- a/pokeys_userspace/pokeys_digital_io.comp
+++ b/pokeys_userspace/pokeys_digital_io.comp
@@ -33,11 +33,8 @@ void setup_pins() {
 void user_mainloop() {
     while (1) {
         for (int i = 0; i < 55; i++) {
-            if (digital_in[i]) {
-                PK_SL_DigitalOutputSet(device, i, 1);
-            } else {
-                PK_SL_DigitalOutputSet(device, i, 0);
-            }
+            digital_out[i] = PK_SL_DigitalInputGet(device, i);
+            PK_SL_DigitalOutputSet(device, i, digital_in[i]);
         }
         usleep(10000);
     }


### PR DESCRIPTION
Related to #25

Create a new modular userspace component for PoKeys in the `pokeys_userspace` subfolder.

* **pokeys_userspace/pokeys_analog_io.comp**
  - Implement analog IO component for PoKeys.
  - Define pins for analog input and output.
  - Connect to PoKeys device and read/write analog values.

* **pokeys_userspace/pokeys_digital_io.comp**
  - Implement digital IO component for PoKeys.
  - Define pins for digital input and output.
  - Connect to PoKeys device and read/write digital values.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zarfld/LinuxCnc_PokeysLibComp/issues/25?shareId=e17a60a6-6d3b-48e8-a7ca-2eea0c63347e).