### PR TITLE
Add missing functionalities to pokeys_userspace

### DIFF
--- a/pokeys_userspace/pokeys_poextbus.comp
+++ b/pokeys_userspace/pokeys_poextbus.comp
@@ -1,0 +1,69 @@
+component pokeys_poextbus "PoExtBus component for PoKeys";
+
+option userspace yes;
+
+pin in bit poextbus_in.# [16];
+pin out bit poextbus_out.# [16];
+
+license "GPL";
+author "Dominik Zarfl";
+
+;;
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "PoKeysLib.h"
+
+sPoKeysDevice* device;
+
+void setup_pins() {
+    for (int i = 0; i < 16; i++) {
+        if (hal_pin_bit_newf(HAL_IN, &(poextbus_in[i]), comp_id, "pokeys_poextbus.poextbus_in.%d", i) < 0) {
+            rtapi_print_msg(RTAPI_MSG_ERR, "ERROR: could not create poextbus_in pin %d\n", i);
+            exit(1);
+        }
+        if (hal_pin_bit_newf(HAL_OUT, &(poextbus_out[i]), comp_id, "pokeys_poextbus.poextbus_out.%d", i) < 0) {
+            rtapi_print_msg(RTAPI_MSG_ERR, "ERROR: could not create poextbus_out pin %d\n", i);
+            exit(1);
+        }
+    }
+}
+
+void user_mainloop() {
+    while (1) {
+        for (int i = 0; i < 16; i++) {
+            poextbus_out[i] = PK_PoExtBusGet(device, i);
+            PK_PoExtBusSet(device, i, poextbus_in[i]);
+        }
+        usleep(10000);
+    }
+}
+
+int rtapi_app_main(void) {
+    comp_id = hal_init("pokeys_poextbus");
+    if (comp_id < 0) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "pokeys_poextbus: ERROR: hal_init() failed\n");
+        return -1;
+    }
+
+    device = PK_ConnectToDevice(0);
+    if (device == NULL) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "pokeys_poextbus: ERROR: could not connect to PoKeys device\n");
+        return -1;
+    }
+
+    setup_pins();
+
+    hal_ready(comp_id);
+    rtapi_print_msg(RTAPI_MSG_INFO, "pokeys_poextbus: installed\n");
+
+    return 0;
+}
+
+void rtapi_app_exit(void) {
+    if (device != NULL) {
+        PK_DisconnectDevice(device);
+    }
+    hal_exit(comp_id);
+}

--- a/pokeys_userspace/pokeys_ponetkbd48cnc.comp
+++ b/pokeys_userspace/pokeys_ponetkbd48cnc.comp
@@ -1,0 +1,69 @@
+component pokeys_ponetkbd48cnc "PoNETkbd48CNC component for PoKeys";
+
+option userspace yes;
+
+pin in bit ponetkbd48cnc_in.# [48];
+pin out bit ponetkbd48cnc_out.# [48];
+
+license "GPL";
+author "Dominik Zarfl";
+
+;;
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "PoKeysLib.h"
+
+sPoKeysDevice* device;
+
+void setup_pins() {
+    for (int i = 0; i < 48; i++) {
+        if (hal_pin_bit_newf(HAL_IN, &(ponetkbd48cnc_in[i]), comp_id, "pokeys_ponetkbd48cnc.ponetkbd48cnc_in.%d", i) < 0) {
+            rtapi_print_msg(RTAPI_MSG_ERR, "ERROR: could not create ponetkbd48cnc_in pin %d\n", i);
+            exit(1);
+        }
+        if (hal_pin_bit_newf(HAL_OUT, &(ponetkbd48cnc_out[i]), comp_id, "pokeys_ponetkbd48cnc.ponetkbd48cnc_out.%d", i) < 0) {
+            rtapi_print_msg(RTAPI_MSG_ERR, "ERROR: could not create ponetkbd48cnc_out pin %d\n", i);
+            exit(1);
+        }
+    }
+}
+
+void user_mainloop() {
+    while (1) {
+        for (int i = 0; i < 48; i++) {
+            ponetkbd48cnc_out[i] = PK_PoNETGetModuleStatus(device, i);
+            PK_PoNETSetModuleStatus(device, i, ponetkbd48cnc_in[i]);
+        }
+        usleep(10000);
+    }
+}
+
+int rtapi_app_main(void) {
+    comp_id = hal_init("pokeys_ponetkbd48cnc");
+    if (comp_id < 0) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "pokeys_ponetkbd48cnc: ERROR: hal_init() failed\n");
+        return -1;
+    }
+
+    device = PK_ConnectToDevice(0);
+    if (device == NULL) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "pokeys_ponetkbd48cnc: ERROR: could not connect to PoKeys device\n");
+        return -1;
+    }
+
+    setup_pins();
+
+    hal_ready(comp_id);
+    rtapi_print_msg(RTAPI_MSG_INFO, "pokeys_ponetkbd48cnc: installed\n");
+
+    return 0;
+}
+
+void rtapi_app_exit(void) {
+    if (device != NULL) {
+        PK_DisconnectDevice(device);
+    }
+    hal_exit(comp_id);
+}

--- a/pokeys_userspace/pokeys_porelay8.comp
+++ b/pokeys_userspace/pokeys_porelay8.comp
@@ -1,0 +1,69 @@
+component pokeys_porelay8 "PoRelay8 component for PoKeys";
+
+option userspace yes;
+
+pin in bit porelay8_in.# [8];
+pin out bit porelay8_out.# [8];
+
+license "GPL";
+author "Dominik Zarfl";
+
+;;
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "PoKeysLib.h"
+
+sPoKeysDevice* device;
+
+void setup_pins() {
+    for (int i = 0; i < 8; i++) {
+        if (hal_pin_bit_newf(HAL_IN, &(porelay8_in[i]), comp_id, "pokeys_porelay8.porelay8_in.%d", i) < 0) {
+            rtapi_print_msg(RTAPI_MSG_ERR, "ERROR: could not create porelay8_in pin %d\n", i);
+            exit(1);
+        }
+        if (hal_pin_bit_newf(HAL_OUT, &(porelay8_out[i]), comp_id, "pokeys_porelay8.porelay8_out.%d", i) < 0) {
+            rtapi_print_msg(RTAPI_MSG_ERR, "ERROR: could not create porelay8_out pin %d\n", i);
+            exit(1);
+        }
+    }
+}
+
+void user_mainloop() {
+    while (1) {
+        for (int i = 0; i < 8; i++) {
+            porelay8_out[i] = PK_PoRelay8_Get(device, i);
+            PK_PoRelay8_Set(device, i, porelay8_in[i]);
+        }
+        usleep(10000);
+    }
+}
+
+int rtapi_app_main(void) {
+    comp_id = hal_init("pokeys_porelay8");
+    if (comp_id < 0) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "pokeys_porelay8: ERROR: hal_init() failed\n");
+        return -1;
+    }
+
+    device = PK_ConnectToDevice(0);
+    if (device == NULL) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "pokeys_porelay8: ERROR: could not connect to PoKeys device\n");
+        return -1;
+    }
+
+    setup_pins();
+
+    hal_ready(comp_id);
+    rtapi_print_msg(RTAPI_MSG_INFO, "pokeys_porelay8: installed\n");
+
+    return 0;
+}
+
+void rtapi_app_exit(void) {
+    if (device != NULL) {
+        PK_DisconnectDevice(device);
+    }
+    hal_exit(comp_id);
+}

--- a/pokeys_userspace/pokeys_pwm.comp
+++ b/pokeys_userspace/pokeys_pwm.comp
@@ -1,0 +1,69 @@
+component pokeys_pwm "PWM component for PoKeys";
+
+option userspace yes;
+
+pin in float pwm_in.# [6];
+pin out float pwm_out.# [6];
+
+license "GPL";
+author "Dominik Zarfl";
+
+;;
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "PoKeysLib.h"
+
+sPoKeysDevice* device;
+
+void setup_pins() {
+    for (int i = 0; i < 6; i++) {
+        if (hal_pin_float_newf(HAL_IN, &(pwm_in[i]), comp_id, "pokeys_pwm.pwm_in.%d", i) < 0) {
+            rtapi_print_msg(RTAPI_MSG_ERR, "ERROR: could not create pwm_in pin %d\n", i);
+            exit(1);
+        }
+        if (hal_pin_float_newf(HAL_OUT, &(pwm_out[i]), comp_id, "pokeys_pwm.pwm_out.%d", i) < 0) {
+            rtapi_print_msg(RTAPI_MSG_ERR, "ERROR: could not create pwm_out pin %d\n", i);
+            exit(1);
+        }
+    }
+}
+
+void user_mainloop() {
+    while (1) {
+        for (int i = 0; i < 6; i++) {
+            pwm_out[i] = PK_SL_PWM_GetDuty(device, i);
+            PK_SL_PWM_SetDuty(device, i, pwm_in[i]);
+        }
+        usleep(10000);
+    }
+}
+
+int rtapi_app_main(void) {
+    comp_id = hal_init("pokeys_pwm");
+    if (comp_id < 0) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "pokeys_pwm: ERROR: hal_init() failed\n");
+        return -1;
+    }
+
+    device = PK_ConnectToDevice(0);
+    if (device == NULL) {
+        rtapi_print_msg(RTAPI_MSG_ERR, "pokeys_pwm: ERROR: could not connect to PoKeys device\n");
+        return -1;
+    }
+
+    setup_pins();
+
+    hal_ready(comp_id);
+    rtapi_print_msg(RTAPI_MSG_INFO, "pokeys_pwm: installed\n");
+
+    return 0;
+}
+
+void rtapi_app_exit(void) {
+    if (device != NULL) {
+        PK_DisconnectDevice(device);
+    }
+    hal_exit(comp_id);
+}


### PR DESCRIPTION
Related to #28

Add missing functionalities to `pokeys_userspace` to match `pokeys.comp`.

* **PWM Functionality:**
  - Add `pokeys_userspace/pokeys_pwm.comp` to implement PWM functionality.
  - Include pin setup for PWM channels.
  - Include main loop to fetch and set PWM values.
  - Connect to PoKeys device in `rtapi_app_main`.
  - Disconnect from PoKeys device in `rtapi_app_exit`.

* **PoExtBus Functionality:**
  - Add `pokeys_userspace/pokeys_poextbus.comp` to implement PoExtBus functionality.
  - Include pin setup for PoExtBus channels.
  - Include main loop to fetch and set PoExtBus values.
  - Connect to PoKeys device in `rtapi_app_main`.
  - Disconnect from PoKeys device in `rtapi_app_exit`.

* **PoRelay8 Functionality:**
  - Add `pokeys_userspace/pokeys_porelay8.comp` to implement PoRelay8 functionality.
  - Include pin setup for PoRelay8 channels.
  - Include main loop to fetch and set PoRelay8 values.
  - Connect to PoKeys device in `rtapi_app_main`.
  - Disconnect from PoKeys device in `rtapi_app_exit`.

* **PoNETkbd48CNC Functionality:**
  - Add `pokeys_userspace/pokeys_ponetkbd48cnc.comp` to implement PoNETkbd48CNC functionality.
  - Include pin setup for PoNETkbd48CNC channels.
  - Include main loop to fetch and set PoNETkbd48CNC values.
  - Connect to PoKeys device in `rtapi_app_main`.
  - Disconnect from PoKeys device in `rtapi_app_exit`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zarfld/LinuxCnc_PokeysLibComp/issues/28?shareId=4ea862c2-8048-4464-882c-f95f28cdb13e).