### PR TITLE
Add tests for pokeys_py package

### DIFF
--- a/tests/test_pev2_motion_control.py
+++ b/tests/test_pev2_motion_control.py
@@ -50,5 +50,32 @@ class TestPEv2MotionControl(unittest.TestCase):
         self.assertEqual(homing_status, 'homing_status')
         mock_pokeyslib.PK_PEv2_GetHomingStatus.assert_called_once_with(self.device, 1)
 
+    @patch('pokeys_py.pev2_motion_control.pokeyslib')
+    def test_manage_homing_signals(self, mock_pokeyslib):
+        self.pev2_motion_control.get_homing_status = MagicMock(return_value=11)
+        self.pev2_motion_control.start_homing = MagicMock()
+        self.pev2_motion_control.set_velocity = MagicMock()
+        self.pev2_motion_control.set_position = MagicMock()
+        self.pev2_motion_control.cancel_homing = MagicMock()
+
+        self.pev2_motion_control.manage_homing_signals(1)
+        self.pev2_motion_control.start_homing.assert_called_once_with(1)
+
+        self.pev2_motion_control.get_homing_status = MagicMock(return_value=12)
+        self.pev2_motion_control.manage_homing_signals(1)
+        self.pev2_motion_control.set_velocity.assert_called_once_with(1, 0.5)
+
+        self.pev2_motion_control.get_homing_status = MagicMock(return_value=13)
+        self.pev2_motion_control.manage_homing_signals(1)
+        self.pev2_motion_control.set_velocity.assert_called_with(1, 0.1)
+
+        self.pev2_motion_control.get_homing_status = MagicMock(return_value=10)
+        self.pev2_motion_control.manage_homing_signals(1)
+        self.pev2_motion_control.set_position.assert_called_once_with(1, 0)
+
+        self.pev2_motion_control.get_homing_status = MagicMock(return_value=0)
+        self.pev2_motion_control.manage_homing_signals(1)
+        self.pev2_motion_control.cancel_homing.assert_called_once_with(1)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Related to #34

Add unit test for `manage_homing_signals` method in `PEv2MotionControl` class.

* Add `test_manage_homing_signals` method to test the `manage_homing_signals` method.
* Mock `get_homing_status`, `start_homing`, `set_velocity`, `set_position`, and `cancel_homing` methods.
* Verify the correct behavior of `manage_homing_signals` based on different homing status values.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zarfld/LinuxCnc_PokeysLibComp/issues/34?shareId=65853c0c-06e0-4727-a2d5-7f653392d038).