### PR TITLE
Add tests for pokeys_py component

### DIFF
--- a/tests/test_analog_io.py
+++ b/tests/test_analog_io.py
@@ -52,5 +52,23 @@ class TestAnalogIO(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.analog_io.setup(99, 'input')
 
+    @patch('pokeys_py.analog_io.pokeyslib')
+    def test_fetch_invalid_value(self, mock_pokeyslib):
+        mock_pokeyslib.PK_SL_AnalogInputGet.side_effect = ValueError("Invalid value")
+        with self.assertRaises(ValueError):
+            self.analog_io.fetch(1)
+
+    @patch('pokeys_py.analog_io.pokeyslib')
+    def test_set_invalid_value(self, mock_pokeyslib):
+        mock_pokeyslib.PK_SL_AnalogOutputSet.side_effect = ValueError("Invalid value")
+        with self.assertRaises(ValueError):
+            self.analog_io.set(1, -1)
+
+    @patch('pokeys_py.analog_io.pokeyslib')
+    def test_setup_invalid_value(self, mock_pokeyslib):
+        mock_pokeyslib.PK_SL_SetPinFunction.side_effect = ValueError("Invalid value")
+        with self.assertRaises(ValueError):
+            self.analog_io.setup(1, 'invalid')
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_analog_io.py
+++ b/tests/test_analog_io.py
@@ -34,5 +34,23 @@ class TestAnalogIO(unittest.TestCase):
         self.analog_io.set(1, 456)
         mock_pokeyslib.PK_SL_AnalogOutputSet.assert_called_once_with(self.device, 1, 456)
 
+    @patch('pokeys_py.analog_io.pokeyslib')
+    def test_fetch_invalid_pin(self, mock_pokeyslib):
+        mock_pokeyslib.PK_SL_AnalogInputGet.side_effect = ValueError("Invalid pin")
+        with self.assertRaises(ValueError):
+            self.analog_io.fetch(99)
+
+    @patch('pokeys_py.analog_io.pokeyslib')
+    def test_set_invalid_pin(self, mock_pokeyslib):
+        mock_pokeyslib.PK_SL_AnalogOutputSet.side_effect = ValueError("Invalid pin")
+        with self.assertRaises(ValueError):
+            self.analog_io.set(99, 456)
+
+    @patch('pokeys_py.analog_io.pokeyslib')
+    def test_setup_invalid_pin(self, mock_pokeyslib):
+        mock_pokeyslib.PK_SL_SetPinFunction.side_effect = ValueError("Invalid pin")
+        with self.assertRaises(ValueError):
+            self.analog_io.setup(99, 'input')
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_can_bus.py
+++ b/tests/test_can_bus.py
@@ -1,0 +1,41 @@
+import unittest
+from unittest.mock import MagicMock, patch
+from pokeys_py.can_bus import CANBus
+
+class TestCANBus(unittest.TestCase):
+    def setUp(self):
+        self.device = MagicMock()
+        self.can_bus = CANBus(self.device)
+
+    @patch('pokeys_py.can_bus.pokeyslib')
+    def test_configure(self, mock_pokeyslib):
+        self.can_bus.configure(500000)
+        mock_pokeyslib.PK_CANConfigure.assert_called_once_with(self.device, 500000)
+
+    @patch('pokeys_py.can_bus.pokeyslib')
+    def test_register_filter(self, mock_pokeyslib):
+        self.can_bus.register_filter(0, 0x123)
+        mock_pokeyslib.PK_CANRegisterFilter.assert_called_once_with(self.device, 0, 0x123)
+
+    @patch('pokeys_py.can_bus.pokeyslib')
+    def test_write(self, mock_pokeyslib):
+        msg = MagicMock()
+        self.can_bus.write(msg)
+        mock_pokeyslib.PK_CANWrite.assert_called_once_with(self.device, msg)
+
+    @patch('pokeys_py.can_bus.pokeyslib')
+    def test_read(self, mock_pokeyslib):
+        msg = MagicMock()
+        status = MagicMock()
+        mock_pokeyslib.PK_CANRead.return_value = 0
+        result = self.can_bus.read(msg, status)
+        self.assertEqual(result, 0)
+        mock_pokeyslib.PK_CANRead.assert_called_once_with(self.device, msg, status)
+
+    @patch('pokeys_py.can_bus.pokeyslib')
+    def test_flush(self, mock_pokeyslib):
+        self.can_bus.flush()
+        mock_pokeyslib.PK_CANFlush.assert_called_once_with(self.device)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_can_bus.py
+++ b/tests/test_can_bus.py
@@ -37,5 +37,35 @@ class TestCANBus(unittest.TestCase):
         self.can_bus.flush()
         mock_pokeyslib.PK_CANFlush.assert_called_once_with(self.device)
 
+    @patch('pokeys_py.can_bus.pokeyslib')
+    def test_configure_invalid_baudrate(self, mock_pokeyslib):
+        mock_pokeyslib.PK_CANConfigure.side_effect = ValueError("Invalid baudrate")
+        with self.assertRaises(ValueError):
+            self.can_bus.configure(123456)
+
+    @patch('pokeys_py.can_bus.pokeyslib')
+    def test_register_filter_invalid_id(self, mock_pokeyslib):
+        mock_pokeyslib.PK_CANRegisterFilter.side_effect = ValueError("Invalid filter ID")
+        with self.assertRaises(ValueError):
+            self.can_bus.register_filter(99, 0x123)
+
+    @patch('pokeys_py.can_bus.pokeyslib')
+    def test_write_invalid_message(self, mock_pokeyslib):
+        mock_pokeyslib.PK_CANWrite.side_effect = ValueError("Invalid message")
+        with self.assertRaises(ValueError):
+            self.can_bus.write(None)
+
+    @patch('pokeys_py.can_bus.pokeyslib')
+    def test_read_invalid_message(self, mock_pokeyslib):
+        mock_pokeyslib.PK_CANRead.side_effect = ValueError("Invalid message")
+        with self.assertRaises(ValueError):
+            self.can_bus.read(None, MagicMock())
+
+    @patch('pokeys_py.can_bus.pokeyslib')
+    def test_flush_error(self, mock_pokeyslib):
+        mock_pokeyslib.PK_CANFlush.side_effect = ValueError("Flush error")
+        with self.assertRaises(ValueError):
+            self.can_bus.flush()
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_counter.py
+++ b/tests/test_counter.py
@@ -51,5 +51,23 @@ class TestCounter(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.counter.setup(99)
 
+    @patch('pokeys_py.counter.pokeyslib')
+    def test_fetch_invalid_value(self, mock_pokeyslib):
+        mock_pokeyslib.PK_DigitalCounterGet.side_effect = ValueError("Invalid value")
+        with self.assertRaises(ValueError):
+            self.counter.fetch(1)
+
+    @patch('pokeys_py.counter.pokeyslib')
+    def test_clear_invalid_value(self, mock_pokeyslib):
+        mock_pokeyslib.PK_DigitalCounterClear.side_effect = ValueError("Invalid value")
+        with self.assertRaises(ValueError):
+            self.counter.clear(1)
+
+    @patch('pokeys_py.counter.pokeyslib')
+    def test_setup_invalid_value(self, mock_pokeyslib):
+        mock_pokeyslib.PK_IsCounterAvailable.side_effect = ValueError("Invalid value")
+        with self.assertRaises(ValueError):
+            self.counter.setup(1)
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_counter.py
+++ b/tests/test_counter.py
@@ -33,5 +33,23 @@ class TestCounter(unittest.TestCase):
         self.assertEqual(self.device.Pins[1].DigitalCounterValue, 0)
         mock_pokeyslib.PK_DigitalCounterClear.assert_called_once_with(self.device)
 
+    @patch('pokeys_py.counter.pokeyslib')
+    def test_fetch_invalid_pin(self, mock_pokeyslib):
+        mock_pokeyslib.PK_DigitalCounterGet.side_effect = ValueError("Invalid pin")
+        with self.assertRaises(ValueError):
+            self.counter.fetch(99)
+
+    @patch('pokeys_py.counter.pokeyslib')
+    def test_clear_invalid_pin(self, mock_pokeyslib):
+        mock_pokeyslib.PK_DigitalCounterClear.side_effect = ValueError("Invalid pin")
+        with self.assertRaises(ValueError):
+            self.counter.clear(99)
+
+    @patch('pokeys_py.counter.pokeyslib')
+    def test_setup_invalid_pin(self, mock_pokeyslib):
+        mock_pokeyslib.PK_IsCounterAvailable.side_effect = ValueError("Invalid pin")
+        with self.assertRaises(ValueError):
+            self.counter.setup(99)
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_digital_io.py
+++ b/tests/test_digital_io.py
@@ -42,5 +42,18 @@ class TestDigitalIO(unittest.TestCase):
         self.digital_io.set(1, 0)
         mock_pokeyslib.PK_SL_DigitalOutputSet.assert_called_with(self.device, 1, 0)
 
+    @patch('pokeys_py.digital_io.pokeyslib')
+    def test_inversion_parameter_handling(self, mock_pokeyslib):
+        self.digital_io.setup(1, 'input')
+        self.digital_io.set(1, 1)
+        mock_pokeyslib.PK_SL_DigitalOutputSet.assert_called_with(self.device, 1, 1)
+        self.digital_io.set(1, 0)
+        mock_pokeyslib.PK_SL_DigitalOutputSet.assert_called_with(self.device, 1, 0)
+        self.digital_io.setup(1, 'output')
+        self.digital_io.set(1, 1)
+        mock_pokeyslib.PK_SL_DigitalOutputSet.assert_called_with(self.device, 1, 1)
+        self.digital_io.set(1, 0)
+        mock_pokeyslib.PK_SL_DigitalOutputSet.assert_called_with(self.device, 1, 0)
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_digital_io.py
+++ b/tests/test_digital_io.py
@@ -34,5 +34,13 @@ class TestDigitalIO(unittest.TestCase):
         self.digital_io.set(1, 0)
         mock_pokeyslib.PK_SL_DigitalOutputSet.assert_called_once_with(self.device, 1, 0)
 
+    @patch('pokeys_py.digital_io.pokeyslib')
+    def test_inversion_parameter(self, mock_pokeyslib):
+        self.digital_io.setup(1, 'input')
+        self.digital_io.set(1, 1)
+        mock_pokeyslib.PK_SL_DigitalOutputSet.assert_called_with(self.device, 1, 1)
+        self.digital_io.set(1, 0)
+        mock_pokeyslib.PK_SL_DigitalOutputSet.assert_called_with(self.device, 1, 0)
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -33,5 +33,18 @@ class TestFunctionalPEv2MotionControl(unittest.TestCase):
         self.pev2.get_homing_status(0)
         self.device.PK_PEv2_GetHomingStatus.assert_called_with(self.device, 0)
 
+    def test_error_conditions_and_edge_cases(self):
+        # Test invalid axis for PEv2 motion control
+        with self.assertRaises(ValueError):
+            self.pev2.set_position(99, 100)
+        with self.assertRaises(ValueError):
+            self.pev2.set_velocity(99, 50)
+        with self.assertRaises(ValueError):
+            self.pev2.start_homing(99)
+        with self.assertRaises(ValueError):
+            self.pev2.cancel_homing(99)
+        with self.assertRaises(ValueError):
+            self.pev2.get_homing_status(99)
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -47,5 +47,60 @@ class TestIntegrationPokeysPy(unittest.TestCase):
         self.device.PK_PEv2_CancelHoming.assert_called_with(self.device, 1)
         self.device.PK_PEv2_GetHomingStatus.assert_called_with(self.device, 1)
 
+    def test_error_conditions_and_edge_cases(self):
+        # Test invalid pin for digital I/O
+        with self.assertRaises(ValueError):
+            self.digital_io.setup(99, 'input')
+        with self.assertRaises(ValueError):
+            self.digital_io.fetch(99)
+        with self.assertRaises(ValueError):
+            self.digital_io.set(99, 1)
+
+        # Test invalid pin for analog I/O
+        with self.assertRaises(ValueError):
+            self.analog_io.setup(99, 'input')
+        with self.assertRaises(ValueError):
+            self.analog_io.fetch(99)
+        with self.assertRaises(ValueError):
+            self.analog_io.set(99, 1.0)
+
+        # Test invalid pin for PWM
+        with self.assertRaises(ValueError):
+            self.pwm.setup(99, 1000, 50)
+        with self.assertRaises(ValueError):
+            self.pwm.fetch(99)
+        with self.assertRaises(ValueError):
+            self.pwm.set(99, 1000, 50)
+
+        # Test invalid pin for counter
+        with self.assertRaises(ValueError):
+            self.counter.setup(99)
+        with self.assertRaises(ValueError):
+            self.counter.fetch(99)
+        with self.assertRaises(ValueError):
+            self.counter.clear(99)
+
+        # Test invalid module ID for PoNET
+        with self.assertRaises(ValueError):
+            self.ponet.setup(99)
+        with self.assertRaises(ValueError):
+            self.ponet.fetch(99)
+        with self.assertRaises(ValueError):
+            self.ponet.set(99, 'data')
+
+        # Test invalid axis for PEv2 motion control
+        with self.assertRaises(ValueError):
+            self.pev2.setup(99, {'param': 'value'})
+        with self.assertRaises(ValueError):
+            self.pev2.set_position(99, 100)
+        with self.assertRaises(ValueError):
+            self.pev2.set_velocity(99, 50)
+        with self.assertRaises(ValueError):
+            self.pev2.start_homing(99)
+        with self.assertRaises(ValueError):
+            self.pev2.cancel_homing(99)
+        with self.assertRaises(ValueError):
+            self.pev2.get_homing_status(99)
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -77,5 +77,59 @@ class TestPerformance(unittest.TestCase):
         latency = (end_time - start_time) / 1000
         self.assertLess(latency, 0.001, "PEv2 Motion Control latency is too high")
 
+    @patch('pokeys_py.digital_io.pokeyslib')
+    def test_digital_io_error_conditions(self, mock_pokeyslib):
+        device = MagicMock()
+        dio = digital_io.DigitalIO(device)
+        with self.assertRaises(ValueError):
+            dio.set(99, 1)
+        with self.assertRaises(ValueError):
+            dio.fetch(99)
+
+    @patch('pokeys_py.analog_io.pokeyslib')
+    def test_analog_io_error_conditions(self, mock_pokeyslib):
+        device = MagicMock()
+        aio = analog_io.AnalogIO(device)
+        with self.assertRaises(ValueError):
+            aio.set(99, 1.0)
+        with self.assertRaises(ValueError):
+            aio.fetch(99)
+
+    @patch('pokeys_py.pwm.pokeyslib')
+    def test_pwm_error_conditions(self, mock_pokeyslib):
+        device = MagicMock()
+        pwm_io = pwm.PWM(device)
+        with self.assertRaises(ValueError):
+            pwm_io.set(99, 1000, 50)
+        with self.assertRaises(ValueError):
+            pwm_io.fetch(99)
+
+    @patch('pokeys_py.counter.pokeyslib')
+    def test_counter_error_conditions(self, mock_pokeyslib):
+        device = MagicMock()
+        counter_io = counter.Counter(device)
+        with self.assertRaises(ValueError):
+            counter_io.clear(99)
+        with self.assertRaises(ValueError):
+            counter_io.fetch(99)
+
+    @patch('pokeys_py.ponet.pokeyslib')
+    def test_ponet_error_conditions(self, mock_pokeyslib):
+        device = MagicMock()
+        ponet_io = ponet.PoNET(device)
+        with self.assertRaises(ValueError):
+            ponet_io.set(99, 1)
+        with self.assertRaises(ValueError):
+            ponet_io.fetch(99)
+
+    @patch('pokeys_py.pev2_motion_control.pokeyslib')
+    def test_pev2_motion_control_error_conditions(self, mock_pokeyslib):
+        device = MagicMock()
+        pev2_io = pev2_motion_control.PEv2MotionControl(device)
+        with self.assertRaises(ValueError):
+            pev2_io.set_position(99, 1000)
+        with self.assertRaises(ValueError):
+            pev2_io.fetch_status()
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_pev2_motion_control.py
+++ b/tests/test_pev2_motion_control.py
@@ -107,5 +107,41 @@ class TestPEv2MotionControl(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.pev2_motion_control.get_homing_status(99)
 
+    @patch('pokeys_py.pev2_motion_control.pokeyslib')
+    def test_fetch_status_invalid_device(self, mock_pokeyslib):
+        mock_pokeyslib.PK_PEv2_StatusGet.side_effect = ValueError("Invalid device")
+        with self.assertRaises(ValueError):
+            self.pev2_motion_control.fetch_status()
+
+    @patch('pokeys_py.pev2_motion_control.pokeyslib')
+    def test_set_position_invalid_value(self, mock_pokeyslib):
+        mock_pokeyslib.PK_PEv2_SetPosition.side_effect = ValueError("Invalid value")
+        with self.assertRaises(ValueError):
+            self.pev2_motion_control.set_position(1, -100)
+
+    @patch('pokeys_py.pev2_motion_control.pokeyslib')
+    def test_set_velocity_invalid_value(self, mock_pokeyslib):
+        mock_pokeyslib.PK_PEv2_SetVelocity.side_effect = ValueError("Invalid value")
+        with self.assertRaises(ValueError):
+            self.pev2_motion_control.set_velocity(1, -200)
+
+    @patch('pokeys_py.pev2_motion_control.pokeyslib')
+    def test_start_homing_invalid_value(self, mock_pokeyslib):
+        mock_pokeyslib.PK_PEv2_StartHoming.side_effect = ValueError("Invalid value")
+        with self.assertRaises(ValueError):
+            self.pev2_motion_control.start_homing(1)
+
+    @patch('pokeys_py.pev2_motion_control.pokeyslib')
+    def test_cancel_homing_invalid_value(self, mock_pokeyslib):
+        mock_pokeyslib.PK_PEv2_CancelHoming.side_effect = ValueError("Invalid value")
+        with self.assertRaises(ValueError):
+            self.pev2_motion_control.cancel_homing(1)
+
+    @patch('pokeys_py.pev2_motion_control.pokeyslib')
+    def test_get_homing_status_invalid_value(self, mock_pokeyslib):
+        mock_pokeyslib.PK_PEv2_GetHomingStatus.side_effect = ValueError("Invalid value")
+        with self.assertRaises(ValueError):
+            self.pev2_motion_control.get_homing_status(1)
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_pev2_motion_control.py
+++ b/tests/test_pev2_motion_control.py
@@ -77,5 +77,35 @@ class TestPEv2MotionControl(unittest.TestCase):
         self.pev2_motion_control.manage_homing_signals(1)
         self.pev2_motion_control.cancel_homing.assert_called_once_with(1)
 
+    @patch('pokeys_py.pev2_motion_control.pokeyslib')
+    def test_set_position_invalid_axis(self, mock_pokeyslib):
+        mock_pokeyslib.PK_PEv2_SetPosition.side_effect = ValueError("Invalid axis")
+        with self.assertRaises(ValueError):
+            self.pev2_motion_control.set_position(99, 100)
+
+    @patch('pokeys_py.pev2_motion_control.pokeyslib')
+    def test_set_velocity_invalid_axis(self, mock_pokeyslib):
+        mock_pokeyslib.PK_PEv2_SetVelocity.side_effect = ValueError("Invalid axis")
+        with self.assertRaises(ValueError):
+            self.pev2_motion_control.set_velocity(99, 200)
+
+    @patch('pokeys_py.pev2_motion_control.pokeyslib')
+    def test_start_homing_invalid_axis(self, mock_pokeyslib):
+        mock_pokeyslib.PK_PEv2_StartHoming.side_effect = ValueError("Invalid axis")
+        with self.assertRaises(ValueError):
+            self.pev2_motion_control.start_homing(99)
+
+    @patch('pokeys_py.pev2_motion_control.pokeyslib')
+    def test_cancel_homing_invalid_axis(self, mock_pokeyslib):
+        mock_pokeyslib.PK_PEv2_CancelHoming.side_effect = ValueError("Invalid axis")
+        with self.assertRaises(ValueError):
+            self.pev2_motion_control.cancel_homing(99)
+
+    @patch('pokeys_py.pev2_motion_control.pokeyslib')
+    def test_get_homing_status_invalid_axis(self, mock_pokeyslib):
+        mock_pokeyslib.PK_PEv2_GetHomingStatus.side_effect = ValueError("Invalid axis")
+        with self.assertRaises(ValueError):
+            self.pev2_motion_control.get_homing_status(99)
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_ponet.py
+++ b/tests/test_ponet.py
@@ -43,5 +43,23 @@ class TestPoNET(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.ponet.setup(99)
 
+    @patch('pokeys_py.ponet.pokeyslib')
+    def test_fetch_invalid_value(self, mock_pokeyslib):
+        mock_pokeyslib.PK_PoNETGetModuleStatus.side_effect = ValueError("Invalid value")
+        with self.assertRaises(ValueError):
+            self.ponet.fetch(1)
+
+    @patch('pokeys_py.ponet.pokeyslib')
+    def test_set_invalid_value(self, mock_pokeyslib):
+        mock_pokeyslib.PK_PoNETSetModuleStatus.side_effect = ValueError("Invalid value")
+        with self.assertRaises(ValueError):
+            self.ponet.set(1, 'invalid_data')
+
+    @patch('pokeys_py.ponet.pokeyslib')
+    def test_setup_invalid_value(self, mock_pokeyslib):
+        mock_pokeyslib.PK_PoNETGetModuleSettings.side_effect = ValueError("Invalid value")
+        with self.assertRaises(ValueError):
+            self.ponet.setup(1)
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_ponet.py
+++ b/tests/test_ponet.py
@@ -25,5 +25,23 @@ class TestPoNET(unittest.TestCase):
         self.ponet.set(1, 'data')
         mock_pokeyslib.PK_PoNETSetModuleStatus.assert_called_once_with(self.device, 1, 'data')
 
+    @patch('pokeys_py.ponet.pokeyslib')
+    def test_fetch_invalid_module_id(self, mock_pokeyslib):
+        mock_pokeyslib.PK_PoNETGetModuleStatusRequest.side_effect = ValueError("Invalid module ID")
+        with self.assertRaises(ValueError):
+            self.ponet.fetch(99)
+
+    @patch('pokeys_py.ponet.pokeyslib')
+    def test_set_invalid_module_id(self, mock_pokeyslib):
+        mock_pokeyslib.PK_PoNETSetModuleStatus.side_effect = ValueError("Invalid module ID")
+        with self.assertRaises(ValueError):
+            self.ponet.set(99, 'data')
+
+    @patch('pokeys_py.ponet.pokeyslib')
+    def test_setup_invalid_module_id(self, mock_pokeyslib):
+        mock_pokeyslib.PK_PoNETGetModuleSettings.side_effect = ValueError("Invalid module ID")
+        with self.assertRaises(ValueError):
+            self.ponet.setup(99)
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_porelay8.py
+++ b/tests/test_porelay8.py
@@ -1,0 +1,29 @@
+import unittest
+from unittest.mock import MagicMock, patch
+from pokeys_py.porelay8 import PoRelay8
+
+class TestPoRelay8(unittest.TestCase):
+    def setUp(self):
+        self.device = MagicMock()
+        self.porelay8 = PoRelay8(self.device)
+
+    @patch('pokeys_py.porelay8.pokeyslib')
+    def test_setup(self, mock_pokeyslib):
+        self.porelay8.setup(1)
+        mock_pokeyslib.PK_PoRelay8_GetModuleSettings.assert_called_once_with(self.device, 1)
+
+    @patch('pokeys_py.porelay8.pokeyslib')
+    def test_fetch(self, mock_pokeyslib):
+        mock_pokeyslib.PK_PoRelay8_GetModuleStatus.return_value = 'module_data'
+        data = self.porelay8.fetch(1)
+        self.assertEqual(data, 'module_data')
+        mock_pokeyslib.PK_PoRelay8_GetModuleStatusRequest.assert_called_once_with(self.device, 1)
+        mock_pokeyslib.PK_PoRelay8_GetModuleStatus.assert_called_once_with(self.device, 1)
+
+    @patch('pokeys_py.porelay8.pokeyslib')
+    def test_set(self, mock_pokeyslib):
+        self.porelay8.set(1, 'data')
+        mock_pokeyslib.PK_PoRelay8_SetModuleStatus.assert_called_once_with(self.device, 1, 'data')
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_porelay8.py
+++ b/tests/test_porelay8.py
@@ -25,5 +25,23 @@ class TestPoRelay8(unittest.TestCase):
         self.porelay8.set(1, 'data')
         mock_pokeyslib.PK_PoRelay8_SetModuleStatus.assert_called_once_with(self.device, 1, 'data')
 
+    @patch('pokeys_py.porelay8.pokeyslib')
+    def test_fetch_invalid_module_id(self, mock_pokeyslib):
+        mock_pokeyslib.PK_PoRelay8_GetModuleStatusRequest.side_effect = ValueError("Invalid module ID")
+        with self.assertRaises(ValueError):
+            self.porelay8.fetch(99)
+
+    @patch('pokeys_py.porelay8.pokeyslib')
+    def test_set_invalid_module_id(self, mock_pokeyslib):
+        mock_pokeyslib.PK_PoRelay8_SetModuleStatus.side_effect = ValueError("Invalid module ID")
+        with self.assertRaises(ValueError):
+            self.porelay8.set(99, 'data')
+
+    @patch('pokeys_py.porelay8.pokeyslib')
+    def test_setup_invalid_module_id(self, mock_pokeyslib):
+        mock_pokeyslib.PK_PoRelay8_GetModuleSettings.side_effect = ValueError("Invalid module ID")
+        with self.assertRaises(ValueError):
+            self.porelay8.setup(99)
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_pwm.py
+++ b/tests/test_pwm.py
@@ -43,5 +43,23 @@ class TestPWM(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.pwm.set(99, 1000, 50)
 
+    @patch('pokeys_py.pwm.pokeyslib')
+    def test_setup_invalid_value(self, mock_pokeyslib):
+        mock_pokeyslib.PK_PWM_Setup.side_effect = ValueError("Invalid value")
+        with self.assertRaises(ValueError):
+            self.pwm.setup(1, -1000, 50)
+
+    @patch('pokeys_py.pwm.pokeyslib')
+    def test_fetch_invalid_value(self, mock_pokeyslib):
+        mock_pokeyslib.PK_PWM_Fetch.side_effect = ValueError("Invalid value")
+        with self.assertRaises(ValueError):
+            self.pwm.fetch(1)
+
+    @patch('pokeys_py.pwm.pokeyslib')
+    def test_set_invalid_value(self, mock_pokeyslib):
+        mock_pokeyslib.PK_PWM_Set.side_effect = ValueError("Invalid value")
+        with self.assertRaises(ValueError):
+            self.pwm.set(1, 1000, -50)
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_pwm.py
+++ b/tests/test_pwm.py
@@ -25,5 +25,23 @@ class TestPWM(unittest.TestCase):
         self.pwm.set(1, 1000, 50)
         mock_pokeyslib.PK_PWM_Set.assert_called_once_with(self.device, 1, 1000, 50)
 
+    @patch('pokeys_py.pwm.pokeyslib')
+    def test_setup_invalid_channel(self, mock_pokeyslib):
+        mock_pokeyslib.PK_PWM_Setup.side_effect = ValueError("Invalid channel")
+        with self.assertRaises(ValueError):
+            self.pwm.setup(99, 1000, 50)
+
+    @patch('pokeys_py.pwm.pokeyslib')
+    def test_fetch_invalid_channel(self, mock_pokeyslib):
+        mock_pokeyslib.PK_PWM_Fetch.side_effect = ValueError("Invalid channel")
+        with self.assertRaises(ValueError):
+            self.pwm.fetch(99)
+
+    @patch('pokeys_py.pwm.pokeyslib')
+    def test_set_invalid_channel(self, mock_pokeyslib):
+        mock_pokeyslib.PK_PWM_Set.side_effect = ValueError("Invalid channel")
+        with self.assertRaises(ValueError):
+            self.pwm.set(99, 1000, 50)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Related to #31

Add comprehensive tests for all functionalities of the `pokeys_py` component.

* **Digital I/O**: Add tests for handling inversion parameters in `tests/test_digital_io.py`.
* **CAN Bus Communication**: Add tests for CAN bus communication in `tests/test_can_bus.py`.
* **PoRelay8 Interaction**: Add tests for interaction with PoRelay8 in `tests/test_porelay8.py`.
* **Analog I/O**: Expand tests for error conditions and edge cases in `tests/test_analog_io.py`.
* **Counter**: Expand tests for error conditions and edge cases in `tests/test_counter.py`.
* **PEv2 Motion Control**: Expand tests for error conditions and edge cases in `tests/test_pev2_motion_control.py`.
* **PoNET**: Expand tests for error conditions and edge cases in `tests/test_ponet.py`.
* **PWM**: Expand tests for error conditions and edge cases in `tests/test_pwm.py`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zarfld/LinuxCnc_PokeysLibComp/issues/31?shareId=6a16b509-f1a1-478f-9fec-ecbbf7efd5bd).