### PR TITLE
Fix CI dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         echo "Updating package lists..."
         sudo apt-get update
         echo "Installing dependencies..."
-        sudo apt-get install -y cmake python3 libmodbus-dev libgpiod-dev libgtk2.0-dev libglade2-dev libxmu-dev libglu1-mesa-dev libgl1-mesa-dev libreadline-dev libjansson-dev libboost-python-dev libboost-thread-dev libboost-system-dev python3-lxml python3-gtk2 debhelper dh-python libudev-dev libxenomai-dev tcl8.6-dev tk8.6-dev libreadline-gplv2-dev asciidoc dvipng graphviz groff imagemagick inkscape python-lxml source-highlight texlive-font-utils texlive-lang-cyrillic texlive-lang-french texlive-lang-german texlive-lang-polish texlive-lang-spanish w3c-linkchecker python-dev python-tk intltool libusb-1.0-0-dev yapps2 dblatex docbook-xsl texlive-extra-utils texlive-fonts-recommended texlive-latex-recommended xsltproc gettext autoconf asciidoc-dblatex libxaw7-dev bwidget libtk-img tclx python-gtk2
+        sudo apt-get install -y cmake python3 libmodbus-dev libgpiod-dev libgtk2.0-dev libglade2-dev libxmu-dev libglu1-mesa-dev libgl1-mesa-dev libreadline-dev libjansson-dev libboost-python-dev libboost-thread-dev libboost-system-dev python3-lxml debhelper dh-python libudev-dev tcl8.6-dev tk8.6-dev asciidoc dvipng graphviz groff imagemagick inkscape source-highlight texlive-font-utils texlive-lang-cyrillic texlive-lang-french texlive-lang-german texlive-lang-polish texlive-lang-spanish w3c-linkchecker python-dev-is-python3 python-tk intltool libusb-1.0-0-dev yapps2 dblatex docbook-xsl texlive-extra-utils texlive-fonts-recommended texlive-latex-recommended xsltproc gettext autoconf asciidoc-dblatex libxaw7-dev bwidget libtk-img tclx
 
     - name: Install LinuxCNC
       run: |
@@ -49,7 +49,7 @@ jobs:
     - name: Install LinuxCNC and PoKeysLib dependencies
       run: |
         echo "Installing LinuxCNC and PoKeysLib dependencies..."
-        sudo apt-get install -y libmodbus-dev libgpiod-dev libgtk2.0-dev libglade2-dev libxmu-dev libglu1-mesa-dev libgl1-mesa-dev libreadline-dev libjansson-dev libboost-python-dev libboost-thread-dev libboost-system-dev python3-lxml python3-gtk2 debhelper dh-python libudev-dev libxenomai-dev tcl8.6-dev tk8.6-dev libreadline-gplv2-dev asciidoc dvipng graphviz groff imagemagick inkscape python-lxml source-highlight texlive-font-utils texlive-lang-cyrillic texlive-lang-french texlive-lang-german texlive-lang-polish texlive-lang-spanish w3c-linkchecker python-dev python-tk intltool libusb-1.0-0-dev yapps2 dblatex docbook-xsl texlive-extra-utils texlive-fonts-recommended texlive-latex-recommended xsltproc gettext autoconf asciidoc-dblatex libxaw7-dev bwidget libtk-img tclx python-gtk2
+        sudo apt-get install -y libmodbus-dev libgpiod-dev libgtk2.0-dev libglade2-dev libxmu-dev libglu1-mesa-dev libgl1-mesa-dev libreadline-dev libjansson-dev libboost-python-dev libboost-thread-dev libboost-system-dev python3-lxml debhelper dh-python libudev-dev tcl8.6-dev tk8.6-dev asciidoc dvipng graphviz groff imagemagick inkscape source-highlight texlive-font-utils texlive-lang-cyrillic texlive-lang-french texlive-lang-german texlive-lang-polish texlive-lang-spanish w3c-linkchecker python-dev-is-python3 python-tk intltool libusb-1.0-0-dev yapps2 dblatex docbook-xsl texlive-extra-utils texlive-fonts-recommended texlive-latex-recommended xsltproc gettext autoconf asciidoc-dblatex libxaw7-dev bwidget libtk-img tclx
 
     - name: Build project
       run: |


### PR DESCRIPTION
Related to #42

Update CI pipeline to resolve package installation errors.

* Replace `python-dev` with `python-dev-is-python3` in `.github/workflows/ci.yml`.
* Remove `python3-gtk2`, `libxenomai-dev`, `libreadline-gplv2-dev`, `python-lxml`, and `python-gtk2` from the dependencies list in `.github/workflows/ci.yml`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zarfld/LinuxCnc_PokeysLibComp/issues/42?shareId=3f1fe173-ac04-43df-ac48-6780aa44093b).