### PR TITLE
Update CI workflow build order

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, debian-latest, mint-latest]
+        os: [debian-latest, raspbian-buster, raspbian-jessie, mint-latest, ubuntu-latest]
     runs-on: ${{ matrix.os }}
 
     steps:


### PR DESCRIPTION
Related to #53

Update the CI workflow build order in the `.github/workflows/ci.yml` file.

* Change the build order in the `matrix.os` section to `debian-latest`, `raspbian-buster`, `raspbian-jessie`, `mint-latest`, `ubuntu-latest`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zarfld/LinuxCnc_PokeysLibComp/issues/53?shareId=24900417-be92-4143-aa49-117875f1bdaa).