### PR TITLE
Add Docker for testing LinuxCNC components in CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,105 +58,15 @@ jobs:
         echo "Runner OS: $RUNNER_OS"
         echo "Runner Architecture: $RUNNER_ARCH"
 
-    - name: Install dependencies
+    - name: Build Docker image
       run: |
-        echo "Updating package lists..."
-        sudo apt-get update
-        echo "Installing dependencies..."
-        retry() {
-          local n=1
-          local max=3
-          local delay=5
-          while true; do
-            "$@" && break || {
-              if [[ $n -lt $max ]]; then
-                ((n++))
-                echo "Command failed. Attempt $n/$max:"
-                sleep $delay;
-              else
-                echo "The command has failed after $n attempts."
-                return 1
-              fi
-            }
-          done
-        }
-        retry sudo apt-get install -y cmake python3 libmodbus-dev libgpiod-dev libgtk2.0-dev libglade2-dev libxmu-dev libglu1-mesa-dev libgl1-mesa-dev libreadline-dev libjansson-dev libboost-python-dev libboost-thread-dev libboost-system-dev python3-lxml debhelper dh-python libudev-dev tcl8.6-dev tk8.6-dev asciidoc dvipng graphviz groff imagemagick inkscape source-highlight texlive-font-utils texlive-lang-cyrillic texlive-lang-french texlive-lang-german texlive-lang-polish texlive-lang-spanish w3c-linkchecker python-dev-is-python3 python-tk intltool libusb-1.0-0-dev yapps2 dblatex docbook-xsl texlive-extra-utils texlive-fonts-recommended texlive-latex-recommended xsltproc gettext autoconf asciidoc-dblatex libxaw7-dev bwidget libtk-img tclx
+        echo "Building Docker image..."
+        docker build -t linuxcnc-pokeyslibcomp .
 
-    - name: Install LinuxCNC
+    - name: Run Docker container and execute tests
       run: |
-        echo "Cloning LinuxCNC repository..."
-        git clone https://github.com/LinuxCNC/linuxcnc.git
-        cd linuxcnc
-        echo "Building LinuxCNC packages..."
-        sudo dpkg-buildpackage -b -uc
-        echo "Installing LinuxCNC packages..."
-        sudo dpkg -i ../linuxcnc-uspace_*.deb ../linuxcnc-dev_*.deb
-
-    - name: Install PoKeysLib
-      run: |
-        echo "Cloning PoKeysLib repository..."
-        git clone https://bitbucket.org/mbosnak/pokeyslib.git
-        cd pokeyslib
-        echo "Building and installing PoKeysLib..."
-        make -f Makefile.noqmake install
-
-    - name: Install LinuxCNC and PoKeysLib dependencies
-      run: |
-        echo "Installing LinuxCNC and PoKeysLib dependencies..."
-        retry() {
-          local n=1
-          local max=3
-          local delay=5
-          while true; do
-            "$@" && break || {
-              if [[ $n -lt $max ]]; then
-                ((n++))
-                echo "Command failed. Attempt $n/$max:"
-                sleep $delay;
-              else
-                echo "The command has failed after $n attempts."
-                return 1
-              fi
-            }
-          done
-        }
-        retry sudo apt-get install -y libmodbus-dev libgpiod-dev libgtk2.0-dev libglade2-dev libxmu-dev libglu1-mesa-dev libgl1-mesa-dev libreadline-dev libjansson-dev libboost-python-dev libboost-thread-dev libboost-system-dev python3-lxml debhelper dh-python libudev-dev tcl8.6-dev tk8.6-dev asciidoc dvipng graphviz groff imagemagick inkscape source-highlight texlive-font-utils texlive-lang-cyrillic texlive-lang-french texlive-lang-german texlive-lang-polish texlive-lang-spanish w3c-linkchecker python-dev-is-python3 python-tk intltool libusb-1.0-0-dev yapps2 dblatex docbook-xsl texlive-extra-utils texlive-fonts-recommended texlive-latex-recommended xsltproc gettext autoconf asciidoc-dblatex libxaw7-dev bwidget libtk-img tclx
-
-    - name: Build project
-      run: |
-        echo "Creating build directory..."
-        mkdir build
-        cd build
-        echo "Configuring build environment with CMake..."
-        cmake ..
-        echo "Compiling project using all available CPU cores..."
-        make -j$(nproc) 2>&1 | tee build.log
-        if [ "${PIPESTATUS[0]}" -ne 0 ]; then
-            echo "Build failed. Check the log file for details: build.log"
-            exit 1
-        fi
-
-    - name: Run tests
-      run: |
-        echo "Running tests..."
-        cd build
-        ctest --output-on-failure 2>&1 | tee test.log
-        if [ "${PIPESTATUS[0]}" -ne 0 ]; then
-            echo "Tests failed. Check the log file for details: test.log"
-            exit 1
-        fi
-
-    - name: Ensure example configs folder exists
-      run: |
-        if [ ! -d "/usr/share/doc/linuxcnc/examples/sample-configs/by_interface/pokeys" ]; then
-            echo "Creating folder for example configs..."
-            sudo mkdir -p /usr/share/doc/linuxcnc/examples/sample-configs/by_interface/pokeys
-        fi
-
-    - name: Copy example configs
-      run: |
-        echo "Copying example configs to the correct folder..."
-        sudo cp -r ./DM542_XXYZ_mill /usr/share/doc/linuxcnc/examples/sample-configs/by_interface/pokeys
+        echo "Running Docker container and executing tests..."
+        docker run --rm linuxcnc-pokeyslibcomp
 
     - name: Upload logs on failure
       if: failure()

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,66 @@
+# Use the base image from jeffersonjhunt/linuxcnc-docker
+FROM jeffersonjhunt/linuxcnc-docker:latest
+
+# Install necessary dependencies for LinuxCNC and PoKeysLib
+RUN apt-get update && apt-get install -y \
+    cmake \
+    python3 \
+    libmodbus-dev \
+    libgpiod-dev \
+    libgtk2.0-dev \
+    libglade2-dev \
+    libxmu-dev \
+    libglu1-mesa-dev \
+    libgl1-mesa-dev \
+    libreadline-dev \
+    libjansson-dev \
+    libboost-python-dev \
+    libboost-thread-dev \
+    libboost-system-dev \
+    python3-lxml \
+    debhelper \
+    dh-python \
+    libudev-dev \
+    tcl8.6-dev \
+    tk8.6-dev \
+    asciidoc \
+    dvipng \
+    graphviz \
+    groff \
+    imagemagick \
+    inkscape \
+    source-highlight \
+    texlive-font-utils \
+    texlive-lang-cyrillic \
+    texlive-lang-french \
+    texlive-lang-german \
+    texlive-lang-polish \
+    texlive-lang-spanish \
+    w3c-linkchecker \
+    python-dev-is-python3 \
+    python-tk \
+    intltool \
+    libusb-1.0-0-dev \
+    yapps2 \
+    dblatex \
+    docbook-xsl \
+    texlive-extra-utils \
+    texlive-fonts-recommended \
+    texlive-latex-recommended \
+    xsltproc \
+    gettext \
+    autoconf \
+    asciidoc-dblatex \
+    libxaw7-dev \
+    bwidget \
+    libtk-img \
+    tclx
+
+# Copy the project files into the Docker image
+COPY . /LinuxCnc_PokeysLibComp
+
+# Set the working directory
+WORKDIR /LinuxCnc_PokeysLibComp
+
+# Set the entrypoint to run tests inside the Docker container
+ENTRYPOINT ["sh", "install.sh"]

--- a/README.md
+++ b/README.md
@@ -344,3 +344,47 @@ Each new feature or bug fix should have its own branch created from the latest v
 ## Conformity with LinuxCNC Guidelines and Canonical Device Interface
 
 This repository aligns with LinuxCNC’s development practices and canonical interfaces. The components have been reviewed and updated to follow LinuxCNC coding guidelines, ensuring that HAL and INI files conform to LinuxCNC’s structure and formatting. Real-time components comply with LinuxCNC’s real-time constraints, and all components follow the canonical interface definitions. The code adheres to LinuxCNC's code style and formatting guidelines, and test cases have been created and run to validate conformity.
+
+## Using Docker for Testing
+
+To simplify the testing process and ensure consistency across different environments, we have integrated Docker into our testing workflow. This allows you to run tests inside a Docker container, providing an isolated and reproducible environment.
+
+### Building the Docker Image
+
+To build the Docker image for testing, follow these steps:
+
+1. Ensure you have Docker installed on your machine. You can download and install Docker from [here](https://www.docker.com/get-started).
+
+2. Clone the repository and navigate to the project directory:
+
+```bash
+git clone https://github.com/zarfld/LinuxCnc_PokeysLibComp.git
+cd LinuxCnc_PokeysLibComp
+```
+
+3. Build the Docker image using the provided `Dockerfile`:
+
+```bash
+docker build -t linuxcnc-pokeyslibcomp .
+```
+
+### Running Tests Inside the Docker Container
+
+Once the Docker image is built, you can run tests inside the Docker container. This ensures that tests are executed in a consistent environment, regardless of the host system.
+
+To run tests inside the Docker container, use the following command:
+
+```bash
+docker run --rm linuxcnc-pokeyslibcomp
+```
+
+This command will start a Docker container from the `linuxcnc-pokeyslibcomp` image and execute the tests inside the container. The `--rm` flag ensures that the container is removed after the tests are completed.
+
+### Benefits of Using Docker for Testing
+
+- **Consistency**: Every test run in the same environment, reducing variability across different CI environments.
+- **Simplicity**: The Docker image provides a pre-configured LinuxCNC environment, which minimizes setup complexity in the CI pipeline.
+- **Isolation**: Running tests inside Docker ensures no interference with other system processes or environment variables.
+- **Cross-platform Compatibility**: The Docker image can be used across different platforms, making local testing and development easier for contributors.
+
+By using Docker for testing, you can ensure that tests are executed in a consistent and isolated environment, reducing the chances of environment-related issues and making it easier to reproduce and debug test failures.


### PR DESCRIPTION
Related to #81

Integrate Docker for testing LinuxCNC components in the CI pipeline.

* **Dockerfile**: Add a new `Dockerfile` to build a Docker image for testing. Use the base image from `jeffersonjhunt/linuxcnc-docker`. Install necessary dependencies for LinuxCNC and PoKeysLib. Copy the project files into the Docker image. Set the entrypoint to run tests inside the Docker container.
* **.github/workflows/ci.yml**: Update the CI pipeline configuration to build the Docker image using the `Dockerfile`. Add a new job to run the Docker container and execute tests. Remove the existing steps for installing dependencies and building LinuxCNC and PoKeysLib directly on the runner.
* **README.md**: Update the documentation to include instructions for using Docker for testing. Add a section explaining how to build and run the Docker image locally. Provide examples of running tests inside the Docker container.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zarfld/LinuxCnc_PokeysLibComp/issues/81?shareId=d8306e76-f1af-46c2-bb46-9d821a29cba4).