### PR TITLE
Fix YAML syntax error in .github/workflows/ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,7 @@ jobs:
         fi
         make -j$(nproc) all
         make -j$(nproc) all 2>&1 | tee "$log_file"
-        if [ "${PIPESTATUS[0]}" -ne 0]; then
+        if [ "${PIPESTATUS[0]}" -ne 0 ]; then
             echo "Build failed. Check the log file for details: $log_file"
             exit 1
         fi


### PR DESCRIPTION
Related to #83

Fix the YAML syntax error on line 23 in `.github/workflows/ci.yml`.

* Correct the syntax error by adding a space before the closing bracket in the `if` statement on line 23
* Ensure the correct indentation and structure of the YAML file

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zarfld/LinuxCnc_PokeysLibComp/issues/83?shareId=d87fb4c2-138f-4fea-be50-255472ce74c1).