### PR TITLE
Add testing component for PoKeys

### DIFF
--- a/tests/mocks/pokeyslib_mock.py
+++ b/tests/mocks/pokeyslib_mock.py
@@ -8,6 +8,9 @@ class PoKeysLibMock:
         self.analog_outputs = {}
         self.counters = {}
         self.pwm_channels = {}
+        self.position_feedback = {}
+        self.velocity_commands = {}
+        self.homing_status = {}
 
     def PK_SL_SetPinFunction(self, device, pin, function):
         pass
@@ -48,23 +51,23 @@ class PoKeysLibMock:
     def PK_PEv2_StatusGet(self, device):
         return random.choice(['status1', 'status2', 'status3'])
 
-    def PK_PEv2_GetPosition(self, device):
-        return random.uniform(0, 100)
+    def PK_PEv2_GetPosition(self, device, axis):
+        return self.position_feedback.get(axis, 0.0)
 
     def PK_PEv2_SetPosition(self, device, axis, position):
-        pass
+        self.position_feedback[axis] = position
 
     def PK_PEv2_SetVelocity(self, device, axis, velocity):
-        pass
+        self.velocity_commands[axis] = velocity
 
     def PK_PEv2_StartHoming(self, device, axis):
-        pass
+        self.homing_status[axis] = 11  # PK_PEAxisState_axHOMINGSTART
 
     def PK_PEv2_CancelHoming(self, device, axis):
-        pass
+        self.homing_status[axis] = 10  # PK_PEAxisState_axHOME
 
     def PK_PEv2_GetHomingStatus(self, device, axis):
-        return random.choice([10, 11, 12, 13])
+        return self.homing_status.get(axis, 10)  # Default to PK_PEAxisState_axHOME
 
     def PK_PoNETGetModuleSettings(self, device, module_id):
         pass


### PR DESCRIPTION
Related to #103

Add methods to simulate the behavior of `pokeyslib` for PEv2 motion control in `tests/mocks/pokeyslib_mock.py`.

* **Position Feedback and Velocity Commands**
  - Add `position_feedback` and `velocity_commands` dictionaries to store position and velocity values.
  - Implement `PK_PEv2_GetPosition` to return position feedback for a given axis.
  - Implement `PK_PEv2_SetPosition` to set position feedback for a given axis.
  - Implement `PK_PEv2_SetVelocity` to set velocity commands for a given axis.

* **Homing Status**
  - Add `homing_status` dictionary to store homing status for each axis.
  - Implement `PK_PEv2_StartHoming` to set homing status to `PK_PEAxisState_axHOMINGSTART`.
  - Implement `PK_PEv2_CancelHoming` to set homing status to `PK_PEAxisState_axHOME`.
  - Implement `PK_PEv2_GetHomingStatus` to return the homing status for a given axis.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zarfld/LinuxCnc_PokeysLibComp/issues/103?shareId=e494ec21-0faa-4481-9fc8-eb1b175fb123).