### PR TITLE
Update digital inputs to follow HAL interface

### DIFF
--- a/docs/wiki/pokeys_PEv2_digins.md
+++ b/docs/wiki/pokeys_PEv2_digins.md
@@ -10,6 +10,25 @@ The `pokeys.[DevID].PEv2` component is designed to interface with PoKeys devices
 
 ### Pins
 
+- `pokeys.[DevID].digin.[PinID].in`: State of the hardware input
+- `pokeys.[DevID].digin.[PinID].in-not`: Inverted state of the input
+- `pokeys.[DevID].PoExtBus.[PoExtBusId]digin.[PinID].in`: State of the PoExtBus input (currently prepared for future Firmware)
+- `pokeys.[DevID].PoExtBus.[PoExtBusId]digin.[PinID].in-not`: Inverted state of the PoExtBus input
+- `pokeys.[DevID].PEv2.digin.Emergency.in`: Emergency input for PulseEnginev2
+- `pokeys.[DevID].PEv2.digin.Probe.in`: Probe input for PulseEnginev2
+- `pokeys.[DevID].PEv2.[PEv2Id].digin.Probe.in`: Probe input for each Axis of PulseEnginev2
+- `pokeys.[DevID].PEv2.[PEv2Id].digin.Home.in`: State of the Home input for Joint[PEv2Id]
+- `pokeys.[DevID].PEv2.[PEv2Id].digin.Home.in-not`: Inverted state of the Home input for Joint[PEv2Id]
+- `pokeys.[DevID].PEv2.[PEv2Id].digin.LimitN.in`: State of the Limit- input for Joint[PEv2Id]
+- `pokeys.[DevID].PEv2.[PEv2Id].digin.LimitN.in-not`: Inverted state of the Limit- input for Joint[PEv2Id]
+- `pokeys.[DevID].PEv2.[PEv2Id].digin.LimitP.in`: State of the Limit+ input for Joint[PEv2Id]
+- `pokeys.[DevID].PEv2.[PEv2Id].digin.LimitP.in-not`: Inverted state of the Limit+ input for Joint[PEv2Id]
+- `pokeys.[DevID].PEv2.[PEv2Id].digin.AxisEnabled.in`: Axis enabled input for each Axis of PulseEnginev2
+- `pokeys.[DevID].kbd48CNC.[ButtonId].Button`: State of the button on kbd48CNC (True if Button pressed)
+
+### Parameters
+
+- `pokeys.[DevID].digin.[PinID].invert`: If TRUE, in is inverted before reading from the hardware
 - `pokeys.[DevID].PEv2.[PEv2Id].digin.Home.Pin`: Home switch pin (0 for external dedicated input)
 - `pokeys.[DevID].PEv2.[PEv2Id].digin.Home.Filter`: Digital filter for Home switch
 - `pokeys.[DevID].PEv2.[PEv2Id].digin.Home.invert`: Invert Home (PoKeys functionality)
@@ -23,22 +42,6 @@ The `pokeys.[DevID].PEv2` component is designed to interface with PoKeys devices
 - `pokeys.[DevID].PEv2.digin.Emergency.invert`: Invert Emergency (PoKeys functionality)
 - `pokeys.[DevID].PEv2.digin.Probe.Pin`: Probe switch pin
 - `pokeys.[DevID].PEv2.digin.Probe.invert`: Invert Probe (PoKeys functionality)
-
-### Parameters
-
-- `pokeys.[DevID].PEv2.[PEv2Id].digin.Home.Pin`: Specifies the pin number for the Home switch. Set to 0 for an external dedicated input.
-- `pokeys.[DevID].PEv2.[PEv2Id].digin.Home.Filter`: Configures the digital filter for the Home switch to debounce the input signal.
-- `pokeys.[DevID].PEv2.[PEv2Id].digin.Home.invert`: Inverts the Home switch input signal if set to TRUE.
-- `pokeys.[DevID].PEv2.[PEv2Id].digin.LimitN.Pin`: Specifies the pin number for the Limit- switch. Set to 0 for an external dedicated input.
-- `pokeys.[DevID].PEv2.[PEv2Id].digin.LimitN.Filter`: Configures the digital filter for the Limit- switch to debounce the input signal.
-- `pokeys.[DevID].PEv2.[PEv2Id].digin.LimitN.invert`: Inverts the Limit- switch input signal if set to TRUE.
-- `pokeys.[DevID].PEv2.[PEv2Id].digin.LimitP.Pin`: Specifies the pin number for the Limit+ switch. Set to 0 for an external dedicated input.
-- `pokeys.[DevID].PEv2.[PEv2Id].digin.LimitP.Filter`: Configures the digital filter for the Limit+ switch to debounce the input signal.
-- `pokeys.[DevID].PEv2.[PEv2Id].digin.LimitP.invert`: Inverts the Limit+ switch input signal if set to TRUE.
-- `pokeys.[DevID].PEv2.digin.Emergency.Pin`: Specifies the pin number for the Emergency switch.
-- `pokeys.[DevID].PEv2.digin.Emergency.invert`: Inverts the Emergency switch input signal if set to TRUE.
-- `pokeys.[DevID].PEv2.digin.Probe.Pin`: Specifies the pin number for the Probe switch.
-- `pokeys.[DevID].PEv2.digin.Probe.invert`: Inverts the Probe switch input signal if set to TRUE.
 
 ## Examples
 

--- a/docs/wiki/pokeys_comp.md
+++ b/docs/wiki/pokeys_comp.md
@@ -14,10 +14,36 @@ Note that `pokeys.comp` is a UserSpace component rather than a realtime componen
 
 - `pokeys.[DevID].digin.[PinID].in`: State of the hardware input
 - `pokeys.[DevID].digin.[PinID].in-not`: Inverted state of the input
+- `pokeys.[DevID].PoExtBus.[PoExtBusId]digin.[PinID].in`: State of the PoExtBus input (currently prepared for future Firmware)
+- `pokeys.[DevID].PoExtBus.[PoExtBusId]digin.[PinID].in-not`: Inverted state of the PoExtBus input
+- `pokeys.[DevID].PEv2.digin.Emergency.in`: Emergency input for PulseEnginev2
+- `pokeys.[DevID].PEv2.digin.Probe.in`: Probe input for PulseEnginev2
+- `pokeys.[DevID].PEv2.[PEv2Id].digin.Probe.in`: Probe input for each Axis of PulseEnginev2
+- `pokeys.[DevID].PEv2.[PEv2Id].digin.Home.in`: State of the Home input for Joint[PEv2Id]
+- `pokeys.[DevID].PEv2.[PEv2Id].digin.Home.in-not`: Inverted state of the Home input for Joint[PEv2Id]
+- `pokeys.[DevID].PEv2.[PEv2Id].digin.LimitN.in`: State of the Limit- input for Joint[PEv2Id]
+- `pokeys.[DevID].PEv2.[PEv2Id].digin.LimitN.in-not`: Inverted state of the Limit- input for Joint[PEv2Id]
+- `pokeys.[DevID].PEv2.[PEv2Id].digin.LimitP.in`: State of the Limit+ input for Joint[PEv2Id]
+- `pokeys.[DevID].PEv2.[PEv2Id].digin.LimitP.in-not`: Inverted state of the Limit+ input for Joint[PEv2Id]
+- `pokeys.[DevID].PEv2.[PEv2Id].digin.AxisEnabled.in`: Axis enabled input for each Axis of PulseEnginev2
+- `pokeys.[DevID].kbd48CNC.[ButtonId].Button`: State of the button on kbd48CNC (True if Button pressed)
 
 ### Parameters
 
 - `pokeys.[DevID].digin.[PinID].invert`: If TRUE, in is inverted before reading from the hardware
+- `pokeys.[DevID].PEv2.[PEv2Id].digin.Home.Pin`: Home switch pin (0 for external dedicated input)
+- `pokeys.[DevID].PEv2.[PEv2Id].digin.Home.Filter`: Digital filter for Home switch
+- `pokeys.[DevID].PEv2.[PEv2Id].digin.Home.invert`: Invert Home (PoKeys functionality)
+- `pokeys.[DevID].PEv2.[PEv2Id].digin.LimitN.Pin`: Limit- switch pin (0 for external dedicated input)
+- `pokeys.[DevID].PEv2.[PEv2Id].digin.LimitN.Filter`: Digital filter for limit- switch
+- `pokeys.[DevID].PEv2.[PEv2Id].digin.LimitN.invert`: Invert limit- (PoKeys functionality)
+- `pokeys.[DevID].PEv2.[PEv2Id].digin.LimitP.Pin`: Limit+ switch pin (0 for external dedicated input)
+- `pokeys.[DevID].PEv2.[PEv2Id].digin.LimitP.Filter`: Digital filter for limit+ switch
+- `pokeys.[DevID].PEv2.[PEv2Id].digin.LimitP.invert`: Invert limit+ (PoKeys functionality)
+- `pokeys.[DevID].PEv2.digin.Emergency.Pin`: Emergency switch pin
+- `pokeys.[DevID].PEv2.digin.Emergency.invert`: Invert Emergency (PoKeys functionality)
+- `pokeys.[DevID].PEv2.digin.Probe.Pin`: Probe switch pin
+- `pokeys.[DevID].PEv2.digin.Probe.invert`: Invert Probe (PoKeys functionality)
 
 ## Digital Output
 
@@ -173,3 +199,43 @@ Note that `pokeys.comp` is a UserSpace component rather than a realtime componen
 - `pokeys.[DevID].info.PulseEngine`                     // Device supports Pulse engine
 - `pokeys.[DevID].info.PulseEnginev2`                   // Device supports Pulse engine v2
 - `pokeys.[DevID].info.EasySensors`                     // Device supports EasySensors
+
+## Examples
+
+### Example 1: Configuring Home Switch
+
+To configure the Home switch for a PoKeys device with DevID 1 and PEv2Id 0, set the following parameters:
+
+```bash
+setp pokeys.1.PEv2.0.digin.Home.Pin 5
+setp pokeys.1.PEv2.0.digin.Home.Filter 10
+setp pokeys.1.PEv2.0.digin.Home.invert TRUE
+```
+
+### Example 2: Configuring Limit Switches
+
+To configure the Limit- and Limit+ switches for a PoKeys device with DevID 1 and PEv2Id 0, set the following parameters:
+
+```bash
+setp pokeys.1.PEv2.0.digin.LimitN.Pin 6
+setp pokeys.1.PEv2.0.digin.LimitN.Filter 10
+setp pokeys.1.PEv2.0.digin.LimitN.invert FALSE
+
+setp pokeys.1.PEv2.0.digin.LimitP.Pin 7
+setp pokeys.1.PEv2.0.digin.LimitP.Filter 10
+setp pokeys.1.PEv2.0.digin.LimitP.invert FALSE
+```
+
+### Example 3: Configuring Emergency and Probe Switches
+
+To configure the Emergency and Probe switches for a PoKeys device with DevID 1, set the following parameters:
+
+```bash
+setp pokeys.1.PEv2.digin.Emergency.Pin 8
+setp pokeys.1.PEv2.digin.Emergency.invert TRUE
+
+setp pokeys.1.PEv2.digin.Probe.Pin 9
+setp pokeys.1.PEv2.digin.Probe.invert FALSE
+```
+
+By following these examples, you can configure the digital inputs and parameters for the `pokeys.[DevID].PEv2` component to suit your specific requirements.

--- a/pokeys_py/digital_io.py
+++ b/pokeys_py/digital_io.py
@@ -45,3 +45,23 @@ class DigitalIO:
             self.pokeyslib.PK_SL_DigitalOutputSet(self.device, pin, value)
         except ValueError:
             raise ValueError(f"Invalid pin {pin}")
+
+    def setup_digin(self, devid, pinid):
+        """
+        Setup a digital input pin with HAL interface.
+        :param devid: Device ID
+        :param pinid: Pin ID
+        """
+        self.setup(pinid, 'input')
+        self.pokeyslib.PK_HAL_SetPin(f"pokeys.{devid}.digin.{pinid}.in", self.fetch(pinid))
+        self.pokeyslib.PK_HAL_SetPin(f"pokeys.{devid}.digin.{pinid}.in-not", not self.fetch(pinid))
+
+    def setup_digout(self, devid, pinid):
+        """
+        Setup a digital output pin with HAL interface.
+        :param devid: Device ID
+        :param pinid: Pin ID
+        """
+        self.setup(pinid, 'output')
+        self.pokeyslib.PK_HAL_SetPin(f"pokeys.{devid}.digout.{pinid}.out", self.fetch(pinid))
+        self.pokeyslib.PK_HAL_SetPin(f"pokeys.{devid}.digout.{pinid}.out-not", not self.fetch(pinid))

--- a/pokeys_rt.comp
+++ b/pokeys_rt.comp
@@ -20,6 +20,47 @@ pin out bit connected.udp;
 pin out bit connected.net;
 pin out bit alive;
 
+pin out unsigned info.PinCount;
+pin out unsigned info.PWMCount;
+pin out unsigned info.BasicEncoderCount;
+pin out unsigned info.EncodersCount;
+pin out unsigned info.FastEncoders;
+pin out unsigned info.UltraFastEncoders;
+pin out unsigned info.PWMinternalFrequency;
+pin out unsigned info.AnalogInputs;
+pin out bit info.KeyMapping;
+pin out bit info.TriggeredKeyMapping;
+pin out bit info.KeyRepeatDelay;
+pin out bit info.DigitalCounters;
+pin out bit info.JoystickButtonAxisMapping;
+pin out bit info.JoystickAnalogToDigitalMapping;
+pin out bit info.Macros;
+pin out bit info.MatrixKeyboard;
+pin out bit info.MatrixKeyboardTriggeredMapping;
+pin out bit info.LCD;
+pin out bit info.MatrixLED;
+pin out bit info.ConnectionSignal;
+pin out bit info.PoExtBus;
+pin out bit info.PoNET;
+pin out bit info.AnalogFiltering;
+pin out bit info.InitOutputsStart;
+pin out bit info.protI2C;
+pin out bit info.prot1wire;
+pin out bit info.AdditionalOptions;
+pin out bit info.LoadStatus;
+pin out bit info.CustomDeviceName;
+pin out bit info.PoTLog27support;
+pin out bit info.SensorList;
+pin out bit info.WebInterface;
+pin out bit info.FailSafeSettings;
+pin out bit info.JoystickHATswitch;
+pin out bit info.PulseEngine;
+pin out bit info.PulseEnginev2;
+pin out bit info.EasySensors;
+
+pin out bit pokeys.[DevID].PoExtBus.[PoExtBusId]digin.[PinID].in;
+pin out bit pokeys.[DevID].PoExtBus.[PoExtBusId]digin.[PinID].in-not;
+
 license "GPL";
 author "Dominik Zarfl";
 option homemod;
@@ -65,8 +106,8 @@ MODULE_LICENSE("GPL");
 //usr/include/tcl8.6/tcl-private/compat/stdlib.h
 ///usr/include/c++/10/tr1/stdlib.h
 
-#include "./PoKeysLibRt.h"
-#include "./PoKeysLibCore.h"
+#include "pokeys_rt/PoKeysLibRt.h"
+#include "pokeys_rt/PoKeysLibCore.h"
 
 #undef POKEYSLIB_USE_LIBUSB
 

--- a/pokeys_rt/pokeys_rt.comp
+++ b/pokeys_rt/pokeys_rt.comp
@@ -56,6 +56,9 @@ pin out bit info.PulseEngine;
 pin out bit info.PulseEnginev2;
 pin out bit info.EasySensors;
 
+pin out bit pokeys.[DevID].PoExtBus.[PoExtBusId]digin.[PinID].in;
+pin out bit pokeys.[DevID].PoExtBus.[PoExtBusId]digin.[PinID].in-not;
+
 license "GPL";
 author "Dominik Zarfl";
 option homemod;

--- a/tests/test_digital_io.py
+++ b/tests/test_digital_io.py
@@ -99,5 +99,30 @@ class TestDigitalIO(unittest.TestCase):
         self.digital_io.set(0, 0)
         mock_pokeyslib.PK_SL_DigitalOutputSet.assert_called_with(self.device, 0, 0)
 
+    @patch('pokeys_py.digital_io.pokeyslib')
+    def test_setup_digin(self, mock_pokeyslib):
+        self.digital_io.setup_digin(0, 1)
+        mock_pokeyslib.PK_HAL_SetPin.assert_any_call("pokeys.0.digin.1.in", mock_pokeyslib.PK_SL_DigitalInputGet.return_value)
+        mock_pokeyslib.PK_HAL_SetPin.assert_any_call("pokeys.0.digin.1.in-not", not mock_pokeyslib.PK_SL_DigitalInputGet.return_value)
+
+    @patch('pokeys_py.digital_io.pokeyslib')
+    def test_setup_digout(self, mock_pokeyslib):
+        self.digital_io.setup_digout(0, 1)
+        mock_pokeyslib.PK_HAL_SetPin.assert_any_call("pokeys.0.digout.1.out", mock_pokeyslib.PK_SL_DigitalInputGet.return_value)
+        mock_pokeyslib.PK_HAL_SetPin.assert_any_call("pokeys.0.digout.1.out-not", not mock_pokeyslib.PK_SL_DigitalInputGet.return_value)
+
+    @patch('pokeys_py.digital_io.pokeyslib')
+    def test_digital_io_parameters(self, mock_pokeyslib):
+        self.digital_io.setup(1, 'input')
+        self.digital_io.set(1, 1)
+        mock_pokeyslib.PK_SL_DigitalOutputSet.assert_called_with(self.device, 1, 1)
+        self.digital_io.set(1, 0)
+        mock_pokeyslib.PK_SL_DigitalOutputSet.assert_called_with(self.device, 1, 0)
+        self.digital_io.setup(1, 'output')
+        self.digital_io.set(1, 1)
+        mock_pokeyslib.PK_SL_DigitalOutputSet.assert_called_with(self.device, 1, 1)
+        self.digital_io.set(1, 0)
+        mock_pokeyslib.PK_SL_DigitalOutputSet.assert_called_with(self.device, 1, 0)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Related to #124

Update `pokeys_py` and `pokeys_rt` to follow the defined HAL interface for Digital Inputs.

* **pokeys_py/digital_io.py**
  - Add pin definitions for `pokeys.[DevID].digin.[PinID].in` and `pokeys.[DevID].digin.[PinID].in-not`
  - Add methods `setup_digin` and `setup_digout` to handle new pin definitions

* **pokeys_rt.comp**
  - Add pin definitions for `pokeys.[DevID].PoExtBus.[PoExtBusId]digin.[PinID].in` and `pokeys.[DevID].PoExtBus.[PoExtBusId]digin.[PinID].in-not`
  - Update includes to use relative paths

* **pokeys_rt/pokeys_rt.comp**
  - Add pin definitions for `pokeys.[DevID].PoExtBus.[PoExtBusId]digin.[PinID].in` and `pokeys.[DevID].PoExtBus.[PoExtBusId]digin.[PinID].in-not`

* **docs/wiki/pokeys_comp.md**
  - Update documentation to include all specified pins and parameters for digital inputs
  - Add examples for configuring Home, Limit, Emergency, and Probe switches

* **docs/wiki/pokeys_PEv2_digins.md**
  - Update documentation to include all specified pins and parameters for digital inputs
  - Add examples for configuring Home, Limit, Emergency, and Probe switches

* **tests/test_digital_io.py**
  - Add tests for new pin definitions and parameters
  - Update existing tests to cover new pin definitions and parameters

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zarfld/LinuxCnc_PokeysLibComp/issues/124?shareId=d792454f-9d07-4152-8b33-048468901fd0).