### PR TITLE
Fix compilation error in pokeys_rt.comp

### DIFF
--- a/pokeys_rt.comp
+++ b/pokeys_rt.comp
@@ -1,5 +1,3 @@
-/*  thois header is only for .comp files
-
 component pokeys_rt "realtime module for pokeys";
 
 description """
@@ -167,15 +165,6 @@ option homemod;
 option extra_link_args "-lPoKeysRt -lpthread";
 option extra_setup;
 ;;
-*/
-/* To incorporate default homing.c file from a local git src tree:
-** enable #define HOMING_BASE set to the path to the current homing.c file.
-** (Note: CUSTOM_HOMEMODULE precludes duplicate api symbols)
-** (Edit myname as required for valid path)
-*/
-
-// #define HOMING_BASE /home/myname/linuxcnc-dev/src/emc/motion/homing.c
-//#define RTAPI
 
 #define STR(s)  #s
 #define XSTR(s) STR(s)


### PR DESCRIPTION
Related to #148

Fix the compilation error in `pokeys_rt.comp`.

* Remove the comment block at the beginning of the file.
* Move the `component` declaration to the start of the file.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zarfld/LinuxCnc_PokeysLibComp/issues/148?shareId=a13cf256-41e5-4ed6-9680-5919877d5f5f).