### PR TITLE
Add compilation tasks for COMP files in pokeys_userspace

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,87 +1,159 @@
 {
-  "version": "2.0.0",
-  "tasks": [
-    {
-      "label": "Pre-Build Setup",
-      "type": "shell",
-      "command": "./install_pokeyslib.sh",
-      "problemMatcher": [],
-      "group": {
-        "kind": "build",
-        "isDefault": false
-      }
-    },
-    {
-      "label": "Compile PoKeys USpace HAL Component",
-      "type": "shell",
-      "command": "sudo halcompile --install pokeys.comp",
-      "problemMatcher": [],
-      "dependsOn": "Pre-Build Setup",
-      "group": {
-        "kind": "build",
-        "isDefault": true
-      }
-    },
-    {
-      "label": "Compile PoKeys_rt.comp HAL Component",
-      "type": "shell",
-      "command": "sudo halcompile --install pokeys_rt.comp",
-      "problemMatcher": [],
-      "dependsOn": "Pre-Build Setup",
-      "group": {
-        "kind": "build",
-        "isDefault": true
-      }
-    },
-    {
-      "label": "Compile homing module for pokeys",
-      "type": "shell",
-      "command": "sudo halcompile --install pokeys_homecomp.comp",
-      "problemMatcher": [],
-      "group": {
-        "kind": "build",
-        "isDefault": true
-      }
-    },
-    {
-      "label": "Compile pokeys_digital_io.comp",
-      "type": "shell",
-      "command": "halcompile --install pokeys_userspace/pokeys_digital_io.comp",
-      "group": {
-        "kind": "build",
-        "isDefault": true
-      },
-      "problemMatcher": []
-    },
-    {
-      "label": "Compile pokeys_analog_io.comp",
-      "type": "shell",
-      "command": "halcompile --install pokeys_userspace/pokeys_analog_io.comp",
-      "group": {
-        "kind": "build",
-        "isDefault": true
-      },
-      "problemMatcher": []
-    },
-    {
-      "label": "Compile pokeys_pev2.comp",
-      "type": "shell",
-      "command": "halcompile --install pokeys_userspace/pokeys_pev2.comp",
-      "group": {
-        "kind": "build",
-        "isDefault": true
-      },
-      "problemMatcher": []
-    },
-    {
-      "label": "Compile pokeys_counters.comp",
-      "type": "shell",
-      "command": "halcompile --install pokeys_userspace/pokeys_counters.comp",
-      "group": {
-        "kind": "build",
-        "isDefault": true
-      },
-      "problemMatcher": []
-    }
-  ]
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Compile pokeys_analog_io.comp",
+            "type": "shell",
+            "command": "halcompile --install pokeys_userspace/pokeys_analog_io.comp",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        },
+        {
+            "label": "Compile pokeys_counters.comp",
+            "type": "shell",
+            "command": "halcompile --install pokeys_userspace/pokeys_counters.comp",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        },
+        {
+            "label": "Compile pokeys_digital_io.comp",
+            "type": "shell",
+            "command": "halcompile --install pokeys_userspace/pokeys_digital_io.comp",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        },
+        {
+            "label": "Compile pokeys_pev2.comp",
+            "type": "shell",
+            "command": "halcompile --install pokeys_userspace/pokeys_pev2.comp",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        },
+        {
+            "label": "Compile pokeys_poextbus.comp",
+            "type": "shell",
+            "command": "halcompile --install pokeys_userspace/pokeys_poextbus.comp",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        },
+        {
+            "label": "Compile pokeys_ponetkbd48cnc.comp",
+            "type": "shell",
+            "command": "halcompile --install pokeys_userspace/pokeys_ponetkbd48cnc.comp",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        },
+        {
+            "label": "Compile pokeys_porelay8.comp",
+            "type": "shell",
+            "command": "halcompile --install pokeys_userspace/pokeys_porelay8.comp",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        },
+        {
+            "label": "Compile pokeys_pwm.comp",
+            "type": "shell",
+            "command": "halcompile --install pokeys_userspace/pokeys_pwm.comp",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        },
+        {
+            "label": "Pre-Build Setup",
+            "type": "shell",
+            "command": "./install_pokeyslib.sh",
+            "problemMatcher": [],
+            "group": {
+                "kind": "build",
+                "isDefault": false
+            }
+        },
+        {
+            "label": "Compile PoKeys USpace HAL Component",
+            "type": "shell",
+            "command": "sudo halcompile --install pokeys.comp",
+            "problemMatcher": [],
+            "dependsOn": "Pre-Build Setup",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        },
+        {
+            "label": "Compile PoKeys_rt.comp HAL Component",
+            "type": "shell",
+            "command": "sudo halcompile --install pokeys_rt.comp",
+            "problemMatcher": [],
+            "dependsOn": "Pre-Build Setup",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        },
+        {
+            "label": "Compile homing module for pokeys",
+            "type": "shell",
+            "command": "sudo halcompile --install pokeys_homecomp.comp",
+            "problemMatcher": [],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        },
+        {
+            "label": "Compile pokeys_digital_io.comp",
+            "type": "shell",
+            "command": "halcompile --install pokeys_userspace/pokeys_digital_io.comp",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "problemMatcher": []
+        },
+        {
+            "label": "Compile pokeys_analog_io.comp",
+            "type": "shell",
+            "command": "halcompile --install pokeys_userspace/pokeys_analog_io.comp",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "problemMatcher": []
+        },
+        {
+            "label": "Compile pokeys_pev2.comp",
+            "type": "shell",
+            "command": "halcompile --install pokeys_userspace/pokeys_pev2.comp",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "problemMatcher": []
+        },
+        {
+            "label": "Compile pokeys_counters.comp",
+            "type": "shell",
+            "command": "halcompile --install pokeys_userspace/pokeys_counters.comp",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "problemMatcher": []
+        }
+    ]
 }


### PR DESCRIPTION
Related to #151

Add compilation tasks for COMP files in `pokeys_userspace` to `.vscode/tasks.json`.

* Add a new task to compile `pokeys_analog_io.comp`.
* Add a new task to compile `pokeys_counters.comp`.
* Add a new task to compile `pokeys_digital_io.comp`.
* Add a new task to compile `pokeys_pev2.comp`.
* Add a new task to compile `pokeys_poextbus.comp`.
* Add a new task to compile `pokeys_ponetkbd48cnc.comp`.
* Add a new task to compile `pokeys_porelay8.comp`.
* Add a new task to compile `pokeys_pwm.comp`.
* Ensure the new tasks are added to the existing tasks list.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zarfld/LinuxCnc_PokeysLibComp/issues/151?shareId=6615326f-ba8a-4ff7-97ae-27cc7efa9c16).