### PR TITLE
Setup Github Codespaces for this project

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,26 @@
+{
+    "name": "LinuxCnc_PokeysLibComp",
+    "image": "debian:12",
+    "build": {
+        "dockerfile": "Dockerfile",
+        "context": ".."
+    },
+    "settings": {
+        "terminal.integrated.shell.linux": "/bin/bash"
+    },
+    "extensions": [
+        "ms-vscode.cpptools",
+        "github.copilot",
+        "eamodio.gitlens"
+    ],
+    "postCreateCommand": "cmake . && make",
+    "workspaceFolder": "/home/codespace/workspace",
+    "remoteUser": "codespace",
+    "features": {
+        "ghcr.io/devcontainers/features/common-utils:1": {
+            "installZsh": "false",
+            "installOhMyZsh": "false"
+        }
+    },
+    "onCreateCommand": "bash -c 'source /home/codespace/workspace/scripts/setup_environment.sh && source /home/codespace/workspace/scripts/build_linuxcnc.sh'"
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,16 @@
-# Use the base image from jeffersonjhunt/linuxcnc-docker
-FROM jeffersonjhunt/linuxcnc-docker:latest
+# Use Debian 12 as the base image
+FROM debian:12
 
 # Install necessary dependencies for LinuxCNC and PoKeysLib
 RUN apt-get update && apt-get install -y \
+    build-essential \
     cmake \
+    linuxcnc-uspace-dev \
+    git \
     python3 \
+    python3-pip \
+    curl \
+    sudo \
     libmodbus-dev \
     libgpiod-dev \
     libgtk2.0-dev \
@@ -55,6 +61,10 @@ RUN apt-get update && apt-get install -y \
     bwidget \
     libtk-img \
     tclx
+
+# Set up non-root user 'codespace' with sudo privileges
+RUN useradd -m -s /bin/bash codespace && \
+    echo 'codespace ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
 # Copy the project files into the Docker image
 COPY . /LinuxCnc_PokeysLibComp


### PR DESCRIPTION
Related to #161

Configure GitHub Codespaces for the project.

* **Dockerfile**:
  - Update base image to Debian 12.
  - Install dependencies: `build-essential`, `cmake`, `linuxcnc-uspace-dev`, `git`, `python3`, `python3-pip`, `curl`, `sudo`.
  - Set up non-root user `codespace` with sudo privileges.

* **.devcontainer/devcontainer.json**:
  - Add configuration for Codespace environment with Debian 12 base image.
  - Install VS Code extensions: `ms-vscode.cpptools`, `github.copilot`, `eamodio.gitlens`.
  - Set post-creation command to `cmake . && make`.
  - Set working directory to `/home/codespace/workspace`.
  - Configure terminal to `/bin/bash`.
  - Include steps to follow section 2.2.1 of the LinuxCNC build instructions for Debian 12.
  - Include steps to clone the LinuxCNC repository, checkout the desired branch, configure, build, and set up the environment.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zarfld/LinuxCnc_PokeysLibComp/issues/161?shareId=a60c30c5-b3e0-429c-93e3-adae4c182515).