### PR TITLE
Update CodeQL Action to v2

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -23,12 +23,12 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
 
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
Related to #170

Update the CodeQL Action to v2 in the GitHub workflow file to address the deprecation warning.

* Update `github/codeql-action/init@v1` to `github/codeql-action/init@v2`.
* Update `github/codeql-action/autobuild@v1` to `github/codeql-action/autobuild@v2`.
* Update `github/codeql-action/analyze@v1` to `github/codeql-action/analyze@v2`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zarfld/LinuxCnc_PokeysLibComp/issues/170?shareId=2e47100d-70b4-49c2-b23a-683583769c94).