### PR TITLE
Fix QEMU setup in CI workflow

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -275,6 +275,10 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
 
+    - name: Add universe repository
+      run: |
+        sudo add-apt-repository universe
+
     - name: Set up QEMU
       run: |
         sudo apt-get update


### PR DESCRIPTION
Related to #177

Add a step to add the `universe` repository before installing QEMU in `ci.yml`.

* Add a step to add the `universe` repository before the QEMU installation step.
* Ensure the `create_images` job includes the `universe` repository addition step.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zarfld/LinuxCnc_PokeysLibComp/issues/177?shareId=c7db94cf-ffb2-4cdc-b437-1ff53711ec49).