### PR TITLE
Fix permission issues when installing dependencies

### DIFF
--- a/ci-prerequisites.sh
+++ b/ci-prerequisites.sh
@@ -2,7 +2,7 @@
 
 # Update package lists
 echo "Updating package lists..."
-apt-get update
+sudo apt-get update
 
 retry() {
     local n=1
@@ -24,7 +24,7 @@ retry() {
 
 # Install eatmydata, git, python3, devscripts, and build-essential
 echo "Installing dependencies..."
-retry apt-get install -y eatmydata git python3 devscripts build-essential
+retry sudo apt-get install -y eatmydata git python3 devscripts build-essential
 
 # Add caching mechanism for dependencies
 cache_dir="$HOME/.cache/linuxcnc"

--- a/ci.yml
+++ b/ci.yml
@@ -67,7 +67,7 @@ jobs:
     - name: Install dependencies
       run: |
         echo "Installing dependencies..."
-        bash ci-prerequisites.sh
+        sudo bash ci-prerequisites.sh
 
     - name: Build Docker image
       run: |

--- a/prerequisites.sh
+++ b/prerequisites.sh
@@ -2,7 +2,7 @@
 
 # Update package lists
 echo "Updating package lists..."
-apt-get update
+sudo apt-get update
 
 retry() {
     local n=1
@@ -45,11 +45,11 @@ if ! dpkg -s linuxcnc-dev >/dev/null 2>&1; then
     if [ "$install_linuxcnc_dev" = "y" ]; then
         # Installing Development Packages needed to build COMP files
         echo "Installing linuxcnc-dev..."
-        retry apt-get install -y linuxcnc-dev
+        retry sudo apt-get install -y linuxcnc-dev
     fi
 else
     echo "Updating linuxcnc-dev..."
-    retry apt-get install --only-upgrade -y linuxcnc-dev
+    retry sudo apt-get install --only-upgrade -y linuxcnc-dev
 fi
 
 # Install or update required packages
@@ -58,37 +58,37 @@ echo "Installing or updating required packages..."
 # Check if git is installed
 if ! dpkg -s git >/dev/null 2>&1; then
     echo "Installing git..."
-    retry apt-get install -y git
+    retry sudo apt-get install -y git
 else
     echo "Updating git..."
-    retry apt-get install --only-upgrade -y git
+    retry sudo apt-get install --only-upgrade -y git
 fi
 
 # Check if build-essential is installed
 if ! dpkg -s build-essential >/dev/null 2>&1; then
     echo "Installing build-essential..."
-    retry apt-get install -y build-essential
+    retry sudo apt-get install -y build-essential
 else
     echo "Updating build-essential..."
-    retry apt-get install --only-upgrade -y build-essential
+    retry sudo apt-get install --only-upgrade -y build-essential
 fi
 
 # Check if libusb-1.0-0 is installed
 if ! dpkg -s libusb-1.0-0 >/dev/null 2>&1; then
     echo "Installing libusb-1.0-0..."
-    retry apt-get install -y libusb-1.0-0
+    retry sudo apt-get install -y libusb-1.0-0
 else
     echo "Updating libusb-1.0-0..."
-    retry apt-get install --only-upgrade -y libusb-1.0-0
+    retry sudo apt-get install --only-upgrade -y libusb-1.0-0
 fi
 
 # Check if libusb-1.0-0-dev is installed
 if ! dpkg -s libusb-1.0-0-dev >/dev/null 2>&1; then
     echo "Installing libusb-1.0-0-dev..."
-    retry apt-get install -y libusb-1.0-0-dev
+    retry sudo apt-get install -y libusb-1.0-0-dev
 else
     echo "Updating libusb-1.0-0-dev..."
-    retry apt-get install --only-upgrade -y libusb-1.0-0-dev
+    retry sudo apt-get install --only-upgrade -y libusb-1.0-0-dev
 fi
 
 # Add caching mechanism for dependencies


### PR DESCRIPTION
Related to #182

Add `sudo` to commands in `ci-prerequisites.sh`, `ci.yml`, and `prerequisites.sh` to resolve permission issues when installing dependencies.

* **ci-prerequisites.sh**
  - Add `sudo` to `apt-get update` command.
  - Add `sudo` to `apt-get install` command.

* **ci.yml**
  - Add `sudo` to `bash ci-prerequisites.sh` command.

* **prerequisites.sh**
  - Add `sudo` to `apt-get update` command.
  - Add `sudo` to `apt-get install` command.
  - Add `sudo` to `apt-get install --only-upgrade` command.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zarfld/LinuxCnc_PokeysLibComp/issues/182?shareId=51a6768b-3662-43f2-8d33-7b0cb206ed68).