### PR TITLE
Add task to load INI configuration in Debugmode

### DIFF
--- a/tasks.json
+++ b/tasks.json
@@ -1,0 +1,64 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Compile HAL Component",
+            "type": "shell",
+            "command": "sudo halcompile --install ${file}",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "problemMatcher": [],
+            "detail": "Compile and install the HAL component."
+        },
+        {
+            "label": "Install PokeysLib",
+            "type": "shell",
+            "command": "chmod +x ./install_pokeyslib.sh && ./install_pokeyslib.sh",
+            "group": {
+                "kind": "build",
+                "isDefault": false
+            },
+            "problemMatcher": [],
+            "detail": "Install the PokeysLib library."
+        },
+        {
+            "label": "Compile Pokeys Component",
+            "type": "shell",
+            "command": "sudo halcompile --install pokeys.comp",
+            "group": {
+                "kind": "build",
+                "isDefault": false
+            },
+            "problemMatcher": [],
+            "detail": "Compile and install the Pokeys component."
+        },
+        {
+            "label": "Compile Pokeys Home Component",
+            "type": "shell",
+            "command": "sudo halcompile --install pokeys_homecomp.comp",
+            "group": {
+                "kind": "build",
+                "isDefault": false
+            },
+            "problemMatcher": [],
+            "detail": "Compile and install the Pokeys Home component."
+        },
+        {
+            "label": "Load INI Configuration",
+            "type": "shell",
+            "command": "linuxcnc -v -d $(file)",
+            "group": {
+                "kind": "none",
+                "isDefault": false
+            },
+            "dependsOn": [
+                "Compile Pokeys Component",
+                "Compile Pokeys Home Component"
+            ],
+            "problemMatcher": [],
+            "detail": "Load the INI configuration for LinuxCNC."
+        }
+    ]
+}


### PR DESCRIPTION
Add a new task to load the INI configuration in `tasks.json`.

* Add a new task labeled "Load INI Configuration" to `.vscode/tasks.json`.
* Set the task type to "shell" and the command to "linuxcnc -v -d $(file)".
* Group the new task under "none".
* Add `dependsOn` attribute to specify preconditions for compiling `pokeys.comp` and `pokeys_homecomp.comp`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zarfld/LinuxCnc_PokeysLibComp/pull/190?shareId=7e6f41c1-8df6-436d-9464-f239b59e687e).