### PR TITLE
Add sponsorships section to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -845,6 +845,8 @@ We appreciate your interest in supporting the LinuxCnc_PokeysLibComp project! Yo
 - **Patreon**: Support us on Patreon by becoming a patron. Visit our [Patreon page](https://www.patreon.com/zarfld) to learn more and contribute.
 - **PayPal**: Make a one-time donation via PayPal. Visit our [PayPal donation page](https://www.paypal.com/donate?hosted_button_id=XXXXXXX) to contribute.
 
+For more detailed information on sponsorship tiers and benefits, as well as instructions on how to sponsor through GitHub Sponsors, Patreon, and PayPal, please refer to our [Sponsorship Page](.github/SPONSORS.md).
+
 Thank you for your support!
 
 ## Setting Up Two-Factor Authentication (2FA) for GitHub Repositories


### PR DESCRIPTION
Related to #135

Add a link to the Sponsorship Page in the README.md for easy access.

* Add a link to `.github/SPONSORS.md` under the sponsorship section.
* Update the sponsorship section to include details on GitHub Sponsors, Patreon, and PayPal.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zarfld/LinuxCnc_PokeysLibComp/pull/203?shareId=9a3cf923-2bb6-43ff-bf15-b95d1e0c583b).