### PR TITLE
Fix missing pokeys homing pin in configuration

### DIFF
--- a/DM542_XXYZ_mill/Pokeys57E_DM542_XXYZ_mill.ini
+++ b/DM542_XXYZ_mill/Pokeys57E_DM542_XXYZ_mill.ini
@@ -51,6 +51,7 @@ COMM_TIMEOUT = 1.0
 COMM_WAIT = 0.010
 BASE_PERIOD = 100000
 SERVO_PERIOD = 1000000
+HOMEMOD=pokeys_homecomp
 
 [POKEYS]
 DEVICE_ID=27295
@@ -73,6 +74,23 @@ PEv2_EmergencyOutputPin=53
 PEv2_PulseGeneratorType=0
 PEv2_PG_swap_stepdir=0
 PEv2_PG_extended_io=0
+
+# AXIS_<> specific configuration
+#
+# PEv2_AxesSwitchConfig
+#	PK_ASO_SWITCH_LIMIT_N: 1 << 0 = 1
+#	PK_ASO_SWITCH_LIMIT_P: 1 << 1 = 2
+#	PK_ASO_SWITCH_HOME: 1 << 2 = 4
+#	PK_ASO_SWITCH_COMBINED_LN_H: 1 << 3 = 8
+#	PK_ASO_SWITCH_COMBINED_LP_H: 1 << 4 = 16
+#	PK_ASO_SWITCH_INVERT_LIMIT_N: 1 << 5 = 32
+#	PK_ASO_SWITCH_INVERT_LIMIT_P: 1 << 6 = 64
+#	PK_ASO_SWITCH_INVERT_HOME: 1 << 7 = 128
+#
+# PEv2_Filter<PEv2PinType >Switch_<n> (PEv2_FilterLimitMSwitch_<n>, PEv2_FilterLimitPSwitch_<n> )
+#	The limit and home switch inputs support digital filtering. The filter value defines the minimum time
+#	for the limit or home switch signal activation (1 unit equals to 100 µs = 0.0001 s) - possible values are
+#	between 0 (no filtering) to 254 (25.4 ms).
 
 PEv2_AxesSwitchConfig_0=0
 PEv2_FilterLimitMSwitch_0=0
@@ -149,6 +167,7 @@ PEv2_Feedback_Encoder_Id_7=0
 [HAL]
 HALUI = halui
 HALFILE = Pokeys57E_DM542_XXYZ_mill.hal
+HALFILE = pokeys_homing.hal
 HALFILE = kbd48CNC.hal
 POSTGUI_HALFILE = postgui_call_list.hal
 SHUTDOWN = shutdown.hal


### PR DESCRIPTION
Related to #216

Add missing parameters and comments to `Pokeys57E_DM542_XXYZ_mill.ini` file.

* Add `HOMEMOD=pokeys_homecomp` to the `[EMCMOT]` section.
* Add `HALFILE = pokeys_homing.hal` to the `[HAL]` section.
* Add missing parameters and comments from `Pokeys57CNC_DM542_XXYZ_mill.ini` to the `[POKEYS]` section.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zarfld/LinuxCnc_PokeysLibComp/pull/220?shareId=d7d68308-0cc8-495c-b0f3-61bd47b09e94).