### PR TITLE
Fix CodeQL analysis for C/C++ code

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -22,6 +22,11 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
 
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y cmake libboost-all-dev
+
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3
       with:
@@ -29,6 +34,8 @@ jobs:
 
     - name: Autobuild
       uses: github/codeql-action/autobuild@v3
+      with:
+        build-command: cmake -DCMAKE_BUILD_TYPE=Release .
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,3 +59,7 @@ install(TARGETS PoKeysLib pokeys_rt
 )
 
 # Ensure compliance with LinuxCNC guidelines and the Canonical Device Interface
+
+# Set the C++ standard to use
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update && apt-get install -y \
     libboost-python-dev \
     libboost-thread-dev \
     libboost-system-dev \
+    libboost-all-dev \
     python3-lxml \
     debhelper \
     dh-python \


### PR DESCRIPTION
Related to #228

Update CodeQL configuration to detect and process C/C++ code correctly.

* **CMakeLists.txt**
  - Set the C++ standard to C++11.
  - Ensure the C++ standard is required.

* **Dockerfile**
  - Add `libboost-all-dev` to the list of installed dependencies.

* **.github/workflows/codeql-analysis.yml**
  - Add a step to install `cmake` and `libboost-all-dev` dependencies.
  - Add `-DCMAKE_BUILD_TYPE=Release` to the `cmake` command in the `Autobuild` step.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zarfld/LinuxCnc_PokeysLibComp/pull/229?shareId=fe0fdb37-a95a-4a64-9bac-e2981794b78c).