### PR TITLE
Add PlantUML comments to homing_statemachines.c

### DIFF
--- a/pokeys_rt/homing_statemachines.c
+++ b/pokeys_rt/homing_statemachines.c
@@ -109,12 +109,22 @@ static int base_1joint_state_machine(int joint_num) {
                 break;
 
             case HOME_UNLOCK:
+                // @startuml
+                // note right of HOME_START
+                // Transition to HOME_UNLOCK if HOME_UNLOCK_FIRST flag is set
+                // end note
+                // @enduml
                 // unlock now
                 SetRotaryUnlock(joint_num, 1);
                 H[joint_num].home_state = HOME_UNLOCK_WAIT;
                 break;
 
             case HOME_UNLOCK_WAIT:
+                // @startuml
+                // note right of HOME_UNLOCK
+                // Transition to HOME_UNLOCK_WAIT if not yet unlocked
+                // end note
+                // @enduml
                 // if not yet unlocked, continue waiting
                 if ((H[joint_num].home_flags & HOME_UNLOCK_FIRST) && !GetRotaryIsUnlocked(joint_num))
                     break;
@@ -147,6 +157,11 @@ static int base_1joint_state_machine(int joint_num) {
                 break;
 
             case HOME_INITIAL_BACKOFF_START:
+                // @startuml
+                // note right of HOME_UNLOCK_WAIT
+                // Transition to HOME_INITIAL_BACKOFF_START if home_search_vel is non-zero
+                // end note
+                // @enduml
                 /** @brief  This state is called if the homing sequence starts at a
                    location where the home switch is already tripped. It
                    starts a move away from the switch. */
@@ -170,6 +185,11 @@ static int base_1joint_state_machine(int joint_num) {
                 break;
 
             case HOME_INITIAL_BACKOFF_WAIT:
+                // @startuml
+                // note right of HOME_INITIAL_BACKOFF_START
+                // Transition to HOME_INITIAL_BACKOFF_WAIT if joint is still moving
+                // end note
+                // @enduml
                 /** @brief  This state is called while the machine is moving off of
                    the home switch.  It terminates when the switch is cleared
                    successfully.  If the move ends or hits a limit before it


### PR DESCRIPTION
Add comments for PlantUML in `pokeys_rt/homing_statemachines.c` to indicate state transitions.

* Add comments for PlantUML at the position where transitions take place in the state machine logic.
* Use the format `// @startuml` and `// @enduml` to denote the start and end of PlantUML diagrams.
* Annotate each state transition with a comment indicating the source and target states.
* Include state names and conditions for better understanding of transitions.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zarfld/LinuxCnc_PokeysLibComp/pull/248?shareId=18c4d8cc-8b38-4ed9-ae44-d67168ad5fda).