### PR TITLE
Use MagicMock for pokeyslib in tests

### DIFF
--- a/pokeys_py/__init__.py
+++ b/pokeys_py/__init__.py
@@ -1,19 +1,26 @@
 # Initialize the pokeys_py package
 
-__all__ = ["digital_io", "analog_io", "pwm", "counter", "ponet", "pev2_motion_control"]
+__all__ = [
+    "digital_io",
+    "analog_io",
+    "pwm",
+    "counter",
+    "ponet",
+    "can_bus",
+    "pev2_motion_control",
+]
 
 import os
+from .telemetry import Telemetry
 
 if os.getenv('CI') == 'true':
     from tests.mocks.pokeyslib import pokeyslib
+    telemetry = Telemetry(dsn="", opt_in=False)
 else:
     import ctypes
     pokeyslib = ctypes.CDLL('/usr/lib/linuxcnc/modules/PoKeysLib.so')
+    telemetry = Telemetry(dsn="your_sentry_dsn_here", opt_in=True)
 
-from .telemetry import Telemetry
-
-# Initialize telemetry collection if the user has opted in
-telemetry = Telemetry(dsn="your_sentry_dsn_here", opt_in=True)
 telemetry.initialize_sentry()
 
 # Add pins for device information

--- a/pokeys_py/can_bus.py
+++ b/pokeys_py/can_bus.py
@@ -1,0 +1,21 @@
+import ctypes
+
+class CANBus:
+    def __init__(self, device, pokeyslib):
+        self.device = device
+        self.pokeyslib = pokeyslib
+
+    def configure(self, bitrate):
+        return self.pokeyslib.PK_CANConfigure(self.device, bitrate)
+
+    def register_filter(self, filter_id, can_id):
+        return self.pokeyslib.PK_CANRegisterFilter(self.device, filter_id, can_id)
+
+    def write(self, msg):
+        return self.pokeyslib.PK_CANWrite(self.device, msg)
+
+    def read(self, msg, status):
+        return self.pokeyslib.PK_CANRead(self.device, msg, status)
+
+    def flush(self):
+        return self.pokeyslib.PK_CANFlush(self.device)

--- a/pokeys_py/ponet.py
+++ b/pokeys_py/ponet.py
@@ -1,11 +1,10 @@
 import ctypes
 
-# Load the PoKeysLib shared library
-pokeyslib = ctypes.CDLL('./pokeys_rt/PoKeysLib.so')
 
 class PoNET:
-    def __init__(self, device):
+    def __init__(self, device, pokeyslib):
         self.device = device
+        self.pokeyslib = pokeyslib
 
     def setup(self, module_id):
         """
@@ -13,7 +12,7 @@ class PoNET:
         :param module_id: Module ID
         """
         try:
-            pokeyslib.PK_PoNETGetModuleSettings(self.device, module_id)
+            self.pokeyslib.PK_PoNETGetModuleSettings(self.device, module_id)
         except ValueError:
             raise ValueError(f"Invalid module ID {module_id}")
 
@@ -24,8 +23,8 @@ class PoNET:
         :return: Module data
         """
         try:
-            pokeyslib.PK_PoNETGetModuleStatusRequest(self.device, module_id)
-            return pokeyslib.PK_PoNETGetModuleStatus(self.device, module_id)
+            self.pokeyslib.PK_PoNETGetModuleStatusRequest(self.device, module_id)
+            return self.pokeyslib.PK_PoNETGetModuleStatus(self.device, module_id)
         except ValueError:
             raise ValueError(f"Invalid module ID {module_id}")
 
@@ -36,6 +35,6 @@ class PoNET:
         :param data: Data to send
         """
         try:
-            pokeyslib.PK_PoNETSetModuleStatus(self.device, module_id, data)
+            self.pokeyslib.PK_PoNETSetModuleStatus(self.device, module_id, data)
         except ValueError:
             raise ValueError(f"Invalid module ID {module_id}")

--- a/tests/mocks/pokeyslib.py
+++ b/tests/mocks/pokeyslib.py
@@ -1,0 +1,3 @@
+from unittest.mock import MagicMock
+
+pokeyslib = MagicMock()

--- a/tests/test_analog_io.py
+++ b/tests/test_analog_io.py
@@ -1,97 +1,83 @@
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 from pokeys_py.analog_io import AnalogIO
 
 class TestAnalogIO(unittest.TestCase):
     def setUp(self):
         self.device = MagicMock()
-        self.analog_io = AnalogIO(self.device, pokeyslib)
+        self.lib = MagicMock()
+        self.analog_io = AnalogIO(self.device, self.lib)
 
-    @patch('pokeys_py.analog_io.pokeyslib')
-    def test_setup_input(self, mock_pokeyslib):
+    def test_setup_input(self):
         self.analog_io.setup(1, 'input')
-        mock_pokeyslib.PK_SL_SetPinFunction.assert_called_once_with(self.device, 1, 1)
+        self.lib.PK_SL_SetPinFunction.assert_called_once_with(self.device, 1, 1)
 
-    @patch('pokeys_py.analog_io.pokeyslib')
-    def test_setup_output(self, mock_pokeyslib):
+    def test_setup_output(self):
         self.analog_io.setup(1, 'output')
-        mock_pokeyslib.PK_SL_SetPinFunction.assert_called_once_with(self.device, 1, 3)
+        self.lib.PK_SL_SetPinFunction.assert_called_once_with(self.device, 1, 3)
 
-    @patch('pokeys_py.analog_io.pokeyslib')
-    def test_setup_invalid_direction(self, mock_pokeyslib):
+    def test_setup_invalid_direction(self):
         with self.assertRaises(ValueError):
             self.analog_io.setup(1, 'invalid')
 
-    @patch('pokeys_py.analog_io.pokeyslib')
-    def test_fetch(self, mock_pokeyslib):
-        mock_pokeyslib.PK_SL_AnalogInputGet.return_value = 123
+    def test_fetch(self):
+        self.lib.PK_SL_AnalogInputGet.return_value = 123
         value = self.analog_io.fetch(1)
         self.assertEqual(value, 123)
-        mock_pokeyslib.PK_SL_AnalogInputGet.assert_called_once_with(self.device, 1)
+        self.lib.PK_SL_AnalogInputGet.assert_called_once_with(self.device, 1)
 
-    @patch('pokeys_py.analog_io.pokeyslib')
-    def test_set(self, mock_pokeyslib):
+    def test_set(self):
         self.analog_io.set(1, 456)
-        mock_pokeyslib.PK_SL_AnalogOutputSet.assert_called_once_with(self.device, 1, 456)
+        self.lib.PK_SL_AnalogOutputSet.assert_called_once_with(self.device, 1, 456)
 
-    @patch('pokeys_py.analog_io.pokeyslib')
-    def test_fetch_invalid_pin(self, mock_pokeyslib):
-        mock_pokeyslib.PK_SL_AnalogInputGet.side_effect = ValueError("Invalid pin")
+    def test_fetch_invalid_pin(self):
+        self.lib.PK_SL_AnalogInputGet.side_effect = ValueError("Invalid pin")
         with self.assertRaises(ValueError):
             self.analog_io.fetch(99)
 
-    @patch('pokeys_py.analog_io.pokeyslib')
-    def test_set_invalid_pin(self, mock_pokeyslib):
-        mock_pokeyslib.PK_SL_AnalogOutputSet.side_effect = ValueError("Invalid pin")
+    def test_set_invalid_pin(self):
+        self.lib.PK_SL_AnalogOutputSet.side_effect = ValueError("Invalid pin")
         with self.assertRaises(ValueError):
             self.analog_io.set(99, 456)
 
-    @patch('pokeys_py.analog_io.pokeyslib')
-    def test_setup_invalid_pin(self, mock_pokeyslib):
-        mock_pokeyslib.PK_SL_SetPinFunction.side_effect = ValueError("Invalid pin")
+    def test_setup_invalid_pin(self):
+        self.lib.PK_SL_SetPinFunction.side_effect = ValueError("Invalid pin")
         with self.assertRaises(ValueError):
             self.analog_io.setup(99, 'input')
 
-    @patch('pokeys_py.analog_io.pokeyslib')
-    def test_fetch_invalid_value(self, mock_pokeyslib):
-        mock_pokeyslib.PK_SL_AnalogInputGet.side_effect = ValueError("Invalid value")
+    def test_fetch_invalid_value(self):
+        self.lib.PK_SL_AnalogInputGet.side_effect = ValueError("Invalid value")
         with self.assertRaises(ValueError):
             self.analog_io.fetch(1)
 
-    @patch('pokeys_py.analog_io.pokeyslib')
-    def test_set_invalid_value(self, mock_pokeyslib):
-        mock_pokeyslib.PK_SL_AnalogOutputSet.side_effect = ValueError("Invalid value")
+    def test_set_invalid_value(self):
+        self.lib.PK_SL_AnalogOutputSet.side_effect = ValueError("Invalid value")
         with self.assertRaises(ValueError):
             self.analog_io.set(1, -1)
 
-    @patch('pokeys_py.analog_io.pokeyslib')
-    def test_setup_invalid_value(self, mock_pokeyslib):
-        mock_pokeyslib.PK_SL_SetPinFunction.side_effect = ValueError("Invalid value")
+    def test_setup_invalid_value(self):
+        self.lib.PK_SL_SetPinFunction.side_effect = ValueError("Invalid value")
         with self.assertRaises(ValueError):
             self.analog_io.setup(1, 'invalid')
 
-    @patch('pokeys_py.analog_io.pokeyslib')
-    def test_analog_input_output_behavior(self, mock_pokeyslib):
+    def test_analog_input_output_behavior(self):
         for i in range(7):
             expected_value = 1.23 * i
             self.analog_io.set(i, expected_value)
             actual_value = self.analog_io.fetch(i)
             self.assertEqual(actual_value, expected_value, f"Analog pin {i} expected {expected_value} but got {actual_value}")
 
-    @patch('pokeys_py.analog_io.pokeyslib')
-    def test_setup_invalid_direction_error_handling(self, mock_pokeyslib):
+    def test_setup_invalid_direction_error_handling(self):
         with self.assertRaises(ValueError):
             self.analog_io.setup(1, 'invalid_direction')
 
-    @patch('pokeys_py.analog_io.pokeyslib')
-    def test_fetch_invalid_pin_error_handling(self, mock_pokeyslib):
-        mock_pokeyslib.PK_SL_AnalogInputGet.side_effect = ValueError("Invalid pin")
+    def test_fetch_invalid_pin_error_handling(self):
+        self.lib.PK_SL_AnalogInputGet.side_effect = ValueError("Invalid pin")
         with self.assertRaises(ValueError):
             self.analog_io.fetch(99)
 
-    @patch('pokeys_py.analog_io.pokeyslib')
-    def test_set_invalid_pin_error_handling(self, mock_pokeyslib):
-        mock_pokeyslib.PK_SL_AnalogOutputSet.side_effect = ValueError("Invalid pin")
+    def test_set_invalid_pin_error_handling(self):
+        self.lib.PK_SL_AnalogOutputSet.side_effect = ValueError("Invalid pin")
         with self.assertRaises(ValueError):
             self.analog_io.set(99, 456)
 

--- a/tests/test_can_bus.py
+++ b/tests/test_can_bus.py
@@ -1,134 +1,114 @@
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 from pokeys_py.can_bus import CANBus
 
 class TestCANBus(unittest.TestCase):
     def setUp(self):
         self.device = MagicMock()
-        self.can_bus = CANBus(self.device)
+        self.lib = MagicMock()
+        self.can_bus = CANBus(self.device, self.lib)
 
-    @patch('pokeys_py.can_bus.pokeyslib')
-    def test_configure(self, mock_pokeyslib):
+    def test_configure(self):
         self.can_bus.configure(500000)
-        mock_pokeyslib.PK_CANConfigure.assert_called_once_with(self.device, 500000)
+        self.lib.PK_CANConfigure.assert_called_once_with(self.device, 500000)
 
-    @patch('pokeys_py.can_bus.pokeyslib')
-    def test_register_filter(self, mock_pokeyslib):
+    def test_register_filter(self):
         self.can_bus.register_filter(0, 0x123)
-        mock_pokeyslib.PK_CANRegisterFilter.assert_called_once_with(self.device, 0, 0x123)
+        self.lib.PK_CANRegisterFilter.assert_called_once_with(self.device, 0, 0x123)
 
-    @patch('pokeys_py.can_bus.pokeyslib')
-    def test_write(self, mock_pokeyslib):
+    def test_write(self):
         msg = MagicMock()
         self.can_bus.write(msg)
-        mock_pokeyslib.PK_CANWrite.assert_called_once_with(self.device, msg)
+        self.lib.PK_CANWrite.assert_called_once_with(self.device, msg)
 
-    @patch('pokeys_py.can_bus.pokeyslib')
-    def test_read(self, mock_pokeyslib):
+    def test_read(self):
         msg = MagicMock()
         status = MagicMock()
-        mock_pokeyslib.PK_CANRead.return_value = 0
+        self.lib.PK_CANRead.return_value = 0
         result = self.can_bus.read(msg, status)
         self.assertEqual(result, 0)
-        mock_pokeyslib.PK_CANRead.assert_called_once_with(self.device, msg, status)
+        self.lib.PK_CANRead.assert_called_once_with(self.device, msg, status)
 
-    @patch('pokeys_py.can_bus.pokeyslib')
-    def test_flush(self, mock_pokeyslib):
+    def test_flush(self):
         self.can_bus.flush()
-        mock_pokeyslib.PK_CANFlush.assert_called_once_with(self.device)
+        self.lib.PK_CANFlush.assert_called_once_with(self.device)
 
-    @patch('pokeys_py.can_bus.pokeyslib')
-    def test_configure_invalid_baudrate(self, mock_pokeyslib):
-        mock_pokeyslib.PK_CANConfigure.side_effect = ValueError("Invalid baudrate")
+    def test_configure_invalid_baudrate(self):
+        self.lib.PK_CANConfigure.side_effect = ValueError("Invalid baudrate")
         with self.assertRaises(ValueError):
             self.can_bus.configure(123456)
 
-    @patch('pokeys_py.can_bus.pokeyslib')
-    def test_register_filter_invalid_id(self, mock_pokeyslib):
-        mock_pokeyslib.PK_CANRegisterFilter.side_effect = ValueError("Invalid filter ID")
+    def test_register_filter_invalid_id(self):
+        self.lib.PK_CANRegisterFilter.side_effect = ValueError("Invalid filter ID")
         with self.assertRaises(ValueError):
             self.can_bus.register_filter(99, 0x123)
 
-    @patch('pokeys_py.can_bus.pokeyslib')
-    def test_write_invalid_message(self, mock_pokeyslib):
-        mock_pokeyslib.PK_CANWrite.side_effect = ValueError("Invalid message")
+    def test_write_invalid_message(self):
+        self.lib.PK_CANWrite.side_effect = ValueError("Invalid message")
         with self.assertRaises(ValueError):
             self.can_bus.write(None)
 
-    @patch('pokeys_py.can_bus.pokeyslib')
-    def test_read_invalid_message(self, mock_pokeyslib):
-        mock_pokeyslib.PK_CANRead.side_effect = ValueError("Invalid message")
+    def test_read_invalid_message(self):
+        self.lib.PK_CANRead.side_effect = ValueError("Invalid message")
         with self.assertRaises(ValueError):
             self.can_bus.read(None, MagicMock())
 
-    @patch('pokeys_py.can_bus.pokeyslib')
-    def test_flush_error(self, mock_pokeyslib):
-        mock_pokeyslib.PK_CANFlush.side_effect = ValueError("Flush error")
+    def test_flush_error(self):
+        self.lib.PK_CANFlush.side_effect = ValueError("Flush error")
         with self.assertRaises(ValueError):
             self.can_bus.flush()
 
-    @patch('pokeys_py.can_bus.pokeyslib')
-    def test_can_bus_initialization(self, mock_pokeyslib):
+    def test_can_bus_initialization(self):
         self.assertIsInstance(self.can_bus, CANBus)
         self.assertEqual(self.can_bus.device, self.device)
 
-    @patch('pokeys_py.can_bus.pokeyslib')
-    def test_can_bus_configuration(self, mock_pokeyslib):
+    def test_can_bus_configuration(self):
         self.can_bus.configure(250000)
-        mock_pokeyslib.PK_CANConfigure.assert_called_once_with(self.device, 250000)
+        self.lib.PK_CANConfigure.assert_called_once_with(self.device, 250000)
 
-    @patch('pokeys_py.can_bus.pokeyslib')
-    def test_can_bus_filter_registration(self, mock_pokeyslib):
+    def test_can_bus_filter_registration(self):
         self.can_bus.register_filter(1, 0x456)
-        mock_pokeyslib.PK_CANRegisterFilter.assert_called_once_with(self.device, 1, 0x456)
+        self.lib.PK_CANRegisterFilter.assert_called_once_with(self.device, 1, 0x456)
 
-    @patch('pokeys_py.can_bus.pokeyslib')
-    def test_can_bus_message_write(self, mock_pokeyslib):
+    def test_can_bus_message_write(self):
         msg = MagicMock()
         self.can_bus.write(msg)
-        mock_pokeyslib.PK_CANWrite.assert_called_once_with(self.device, msg)
+        self.lib.PK_CANWrite.assert_called_once_with(self.device, msg)
 
-    @patch('pokeys_py.can_bus.pokeyslib')
-    def test_can_bus_message_read(self, mock_pokeyslib):
+    def test_can_bus_message_read(self):
         msg = MagicMock()
         status = MagicMock()
-        mock_pokeyslib.PK_CANRead.return_value = 0
+        self.lib.PK_CANRead.return_value = 0
         result = self.can_bus.read(msg, status)
         self.assertEqual(result, 0)
-        mock_pokeyslib.PK_CANRead.assert_called_once_with(self.device, msg, status)
+        self.lib.PK_CANRead.assert_called_once_with(self.device, msg, status)
 
-    @patch('pokeys_py.can_bus.pokeyslib')
-    def test_can_bus_flush(self, mock_pokeyslib):
+    def test_can_bus_flush(self):
         self.can_bus.flush()
-        mock_pokeyslib.PK_CANFlush.assert_called_once_with(self.device)
+        self.lib.PK_CANFlush.assert_called_once_with(self.device)
 
-    @patch('pokeys_py.can_bus.pokeyslib')
-    def test_can_bus_invalid_baudrate(self, mock_pokeyslib):
-        mock_pokeyslib.PK_CANConfigure.side_effect = ValueError("Invalid baudrate")
+    def test_can_bus_invalid_baudrate(self):
+        self.lib.PK_CANConfigure.side_effect = ValueError("Invalid baudrate")
         with self.assertRaises(ValueError):
             self.can_bus.configure(123456)
 
-    @patch('pokeys_py.can_bus.pokeyslib')
-    def test_can_bus_invalid_filter_id(self, mock_pokeyslib):
-        mock_pokeyslib.PK_CANRegisterFilter.side_effect = ValueError("Invalid filter ID")
+    def test_can_bus_invalid_filter_id(self):
+        self.lib.PK_CANRegisterFilter.side_effect = ValueError("Invalid filter ID")
         with self.assertRaises(ValueError):
             self.can_bus.register_filter(99, 0x123)
 
-    @patch('pokeys_py.can_bus.pokeyslib')
-    def test_can_bus_invalid_message_write(self, mock_pokeyslib):
-        mock_pokeyslib.PK_CANWrite.side_effect = ValueError("Invalid message")
+    def test_can_bus_invalid_message_write(self):
+        self.lib.PK_CANWrite.side_effect = ValueError("Invalid message")
         with self.assertRaises(ValueError):
             self.can_bus.write(None)
 
-    @patch('pokeys_py.can_bus.pokeyslib')
-    def test_can_bus_invalid_message_read(self, mock_pokeyslib):
-        mock_pokeyslib.PK_CANRead.side_effect = ValueError("Invalid message")
+    def test_can_bus_invalid_message_read(self):
+        self.lib.PK_CANRead.side_effect = ValueError("Invalid message")
         with self.assertRaises(ValueError):
             self.can_bus.read(None, MagicMock())
 
-    @patch('pokeys_py.can_bus.pokeyslib')
-    def test_can_bus_flush_error(self, mock_pokeyslib):
-        mock_pokeyslib.PK_CANFlush.side_effect = ValueError("Flush error")
+    def test_can_bus_flush_error(self):
+        self.lib.PK_CANFlush.side_effect = ValueError("Flush error")
         with self.assertRaises(ValueError):
             self.can_bus.flush()
 

--- a/tests/test_counter.py
+++ b/tests/test_counter.py
@@ -1,81 +1,71 @@
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 from pokeys_py.counter import Counter
 
 class TestCounter(unittest.TestCase):
     def setUp(self):
         self.device = MagicMock()
-        self.counter = Counter(self.device, pokeyslib)
+        self.lib = MagicMock()
+        self.counter = Counter(self.device, self.lib)
 
-    @patch('pokeys_py.counter.pokeyslib', new_callable=lambda: pokeyslib)
-    def test_setup(self, mock_pokeyslib):
-        mock_pokeyslib.PK_IsCounterAvailable.return_value = True
+    def test_setup(self):
+        self.lib.PK_IsCounterAvailable.return_value = True
         self.counter.setup(1)
-        mock_pokeyslib.PK_IsCounterAvailable.assert_called_once_with(self.device, 1)
-        mock_pokeyslib.PK_PinConfigurationSet.assert_called_once_with(self.device)
+        self.lib.PK_IsCounterAvailable.assert_called_once_with(self.device, 1)
+        self.lib.PK_PinConfigurationSet.assert_called_once_with(self.device)
 
-    @patch('pokeys_py.counter.pokeyslib', new_callable=lambda: pokeyslib)
-    def test_setup_counter_not_available(self, mock_pokeyslib):
-        mock_pokeyslib.PK_IsCounterAvailable.return_value = False
+    def test_setup_counter_not_available(self):
+        self.lib.PK_IsCounterAvailable.return_value = False
         with self.assertRaises(ValueError):
             self.counter.setup(1)
 
-    @patch('pokeys_py.counter.pokeyslib', new_callable=lambda: pokeyslib)
-    def test_fetch(self, mock_pokeyslib):
+    def test_fetch(self):
         self.device.Pins[1].DigitalCounterValue = 123
         value = self.counter.fetch(1)
         self.assertEqual(value, 123)
-        mock_pokeyslib.PK_DigitalCounterGet.assert_called_once_with(self.device)
+        self.lib.PK_DigitalCounterGet.assert_called_once_with(self.device)
 
-    @patch('pokeys_py.counter.pokeyslib', new_callable=lambda: pokeyslib)
-    def test_clear(self, mock_pokeyslib):
+    def test_clear(self):
         self.counter.clear(1)
         self.assertEqual(self.device.Pins[1].DigitalCounterValue, 0)
-        mock_pokeyslib.PK_DigitalCounterClear.assert_called_once_with(self.device)
+        self.lib.PK_DigitalCounterClear.assert_called_once_with(self.device)
 
-    @patch('pokeys_py.counter.pokeyslib', new_callable=lambda: pokeyslib)
-    def test_fetch_invalid_pin(self, mock_pokeyslib):
-        mock_pokeyslib.PK_DigitalCounterGet.side_effect = ValueError("Invalid pin")
+    def test_fetch_invalid_pin(self):
+        self.lib.PK_DigitalCounterGet.side_effect = ValueError("Invalid pin")
         with self.assertRaises(ValueError):
             self.counter.fetch(99)
 
-    @patch('pokeys_py.counter.pokeyslib', new_callable=lambda: pokeyslib)
-    def test_clear_invalid_pin(self, mock_pokeyslib):
-        mock_pokeyslib.PK_DigitalCounterClear.side_effect = ValueError("Invalid pin")
+    def test_clear_invalid_pin(self):
+        self.lib.PK_DigitalCounterClear.side_effect = ValueError("Invalid pin")
         with self.assertRaises(ValueError):
             self.counter.clear(99)
 
-    @patch('pokeys_py.counter.pokeyslib', new_callable=lambda: pokeyslib)
-    def test_setup_invalid_pin(self, mock_pokeyslib):
-        mock_pokeyslib.PK_IsCounterAvailable.side_effect = ValueError("Invalid pin")
+    def test_setup_invalid_pin(self):
+        self.lib.PK_IsCounterAvailable.side_effect = ValueError("Invalid pin")
         with self.assertRaises(ValueError):
             self.counter.setup(99)
 
-    @patch('pokeys_py.counter.pokeyslib', new_callable=lambda: pokeyslib)
-    def test_fetch_invalid_value(self, mock_pokeyslib):
-        mock_pokeyslib.PK_DigitalCounterGet.side_effect = ValueError("Invalid value")
+    def test_fetch_invalid_value(self):
+        self.lib.PK_DigitalCounterGet.side_effect = ValueError("Invalid value")
         with self.assertRaises(ValueError):
             self.counter.fetch(1)
 
-    @patch('pokeys_py.counter.pokeyslib', new_callable=lambda: pokeyslib)
-    def test_clear_invalid_value(self, mock_pokeyslib):
-        mock_pokeyslib.PK_DigitalCounterClear.side_effect = ValueError("Invalid value")
+    def test_clear_invalid_value(self):
+        self.lib.PK_DigitalCounterClear.side_effect = ValueError("Invalid value")
         with self.assertRaises(ValueError):
             self.counter.clear(1)
 
-    @patch('pokeys_py.counter.pokeyslib', new_callable=lambda: pokeyslib)
-    def test_setup_invalid_value(self, mock_pokeyslib):
-        mock_pokeyslib.PK_IsCounterAvailable.side_effect = ValueError("Invalid value")
+    def test_setup_invalid_value(self):
+        self.lib.PK_IsCounterAvailable.side_effect = ValueError("Invalid value")
         with self.assertRaises(ValueError):
             self.counter.setup(1)
 
-    @patch('pokeys_py.counter.pokeyslib', new_callable=lambda: pokeyslib)
-    def test_counter_functionality(self, mock_pokeyslib):
+    def test_counter_functionality(self):
         for i in range(8):
             # Test correct mapping of counter pins
             expected_value = i * 100
             self.counter.setup(i)
-            mock_pokeyslib.PK_DigitalCounterSet(self.device, i, expected_value)
+            self.lib.PK_DigitalCounterSet(self.device, i, expected_value)
             actual_value = self.counter.fetch(i)
             self.assertEqual(actual_value, expected_value, f"Counter pin {i} expected {expected_value} but got {actual_value}")
 
@@ -84,21 +74,18 @@ class TestCounter(unittest.TestCase):
             actual_value = self.counter.fetch(i)
             self.assertEqual(actual_value, 0, f"Counter pin {i} clear expected 0 but got {actual_value}")
 
-    @patch('pokeys_py.counter.pokeyslib', new_callable=lambda: pokeyslib)
-    def test_setup_invalid_pin_error_handling(self, mock_pokeyslib):
-        mock_pokeyslib.PK_IsCounterAvailable.side_effect = ValueError("Invalid pin")
+    def test_setup_invalid_pin_error_handling(self):
+        self.lib.PK_IsCounterAvailable.side_effect = ValueError("Invalid pin")
         with self.assertRaises(ValueError):
             self.counter.setup(99)
 
-    @patch('pokeys_py.counter.pokeyslib', new_callable=lambda: pokeyslib)
-    def test_fetch_invalid_pin_error_handling(self, mock_pokeyslib):
-        mock_pokeyslib.PK_DigitalCounterGet.side_effect = ValueError("Invalid pin")
+    def test_fetch_invalid_pin_error_handling(self):
+        self.lib.PK_DigitalCounterGet.side_effect = ValueError("Invalid pin")
         with self.assertRaises(ValueError):
             self.counter.fetch(99)
 
-    @patch('pokeys_py.counter.pokeyslib', new_callable=lambda: pokeyslib)
-    def test_clear_invalid_pin_error_handling(self, mock_pokeyslib):
-        mock_pokeyslib.PK_DigitalCounterClear.side_effect = ValueError("Invalid pin")
+    def test_clear_invalid_pin_error_handling(self):
+        self.lib.PK_DigitalCounterClear.side_effect = ValueError("Invalid pin")
         with self.assertRaises(ValueError):
             self.counter.clear(99)
 

--- a/tests/test_digital_io.py
+++ b/tests/test_digital_io.py
@@ -1,62 +1,55 @@
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 from pokeys_py.digital_io import DigitalIO
 
 class TestDigitalIO(unittest.TestCase):
     def setUp(self):
         self.device = MagicMock()
-        self.digital_io = DigitalIO(self.device, pokeyslib)
+        self.lib = MagicMock()
+        self.digital_io = DigitalIO(self.device, self.lib)
 
-    @patch('pokeys_py.digital_io.pokeyslib')
-    def test_setup_input(self, mock_pokeyslib):
+    def test_setup_input(self):
         self.digital_io.setup(1, 'input')
-        mock_pokeyslib.PK_SL_SetPinFunction.assert_called_once_with(self.device, 1, 2)
+        self.lib.PK_SL_SetPinFunction.assert_called_once_with(self.device, 1, 2)
 
-    @patch('pokeys_py.digital_io.pokeyslib')
-    def test_setup_output(self, mock_pokeyslib):
+    def test_setup_output(self):
         self.digital_io.setup(1, 'output')
-        mock_pokeyslib.PK_SL_SetPinFunction.assert_called_once_with(self.device, 1, 4)
+        self.lib.PK_SL_SetPinFunction.assert_called_once_with(self.device, 1, 4)
 
-    @patch('pokeys_py.digital_io.pokeyslib')
-    def test_setup_invalid_direction(self, mock_pokeyslib):
+    def test_setup_invalid_direction(self):
         with self.assertRaises(ValueError):
             self.digital_io.setup(1, 'invalid')
 
-    @patch('pokeys_py.digital_io.pokeyslib')
-    def test_fetch(self, mock_pokeyslib):
-        mock_pokeyslib.PK_SL_DigitalInputGet.return_value = 1
+    def test_fetch(self):
+        self.lib.PK_SL_DigitalInputGet.return_value = 1
         value = self.digital_io.fetch(1)
         self.assertEqual(value, 1)
-        mock_pokeyslib.PK_SL_DigitalInputGet.assert_called_once_with(self.device, 1)
+        self.lib.PK_SL_DigitalInputGet.assert_called_once_with(self.device, 1)
 
-    @patch('pokeys_py.digital_io.pokeyslib')
-    def test_set(self, mock_pokeyslib):
+    def test_set(self):
         self.digital_io.set(1, 0)
-        mock_pokeyslib.PK_SL_DigitalOutputSet.assert_called_once_with(self.device, 1, 0)
+        self.lib.PK_SL_DigitalOutputSet.assert_called_once_with(self.device, 1, 0)
 
-    @patch('pokeys_py.digital_io.pokeyslib')
-    def test_inversion_parameter(self, mock_pokeyslib):
+    def test_inversion_parameter(self):
         self.digital_io.setup(1, 'input')
         self.digital_io.set(1, 1)
-        mock_pokeyslib.PK_SL_DigitalOutputSet.assert_called_with(self.device, 1, 1)
+        self.lib.PK_SL_DigitalOutputSet.assert_called_with(self.device, 1, 1)
         self.digital_io.set(1, 0)
-        mock_pokeyslib.PK_SL_DigitalOutputSet.assert_called_with(self.device, 1, 0)
+        self.lib.PK_SL_DigitalOutputSet.assert_called_with(self.device, 1, 0)
 
-    @patch('pokeys_py.digital_io.pokeyslib')
-    def test_inversion_parameter_handling(self, mock_pokeyslib):
+    def test_inversion_parameter_handling(self):
         self.digital_io.setup(1, 'input')
         self.digital_io.set(1, 1)
-        mock_pokeyslib.PK_SL_DigitalOutputSet.assert_called_with(self.device, 1, 1)
+        self.lib.PK_SL_DigitalOutputSet.assert_called_with(self.device, 1, 1)
         self.digital_io.set(1, 0)
-        mock_pokeyslib.PK_SL_DigitalOutputSet.assert_called_with(self.device, 1, 0)
+        self.lib.PK_SL_DigitalOutputSet.assert_called_with(self.device, 1, 0)
         self.digital_io.setup(1, 'output')
         self.digital_io.set(1, 1)
-        mock_pokeyslib.PK_SL_DigitalOutputSet.assert_called_with(self.device, 1, 1)
+        self.lib.PK_SL_DigitalOutputSet.assert_called_with(self.device, 1, 1)
         self.digital_io.set(1, 0)
-        mock_pokeyslib.PK_SL_DigitalOutputSet.assert_called_with(self.device, 1, 0)
+        self.lib.PK_SL_DigitalOutputSet.assert_called_with(self.device, 1, 0)
 
-    @patch('pokeys_py.digital_io.pokeyslib')
-    def test_digital_io_behavior(self, mock_pokeyslib):
+    def test_digital_io_behavior(self):
         for i in range(55):
             expected_value = i % 2
             self.digital_io.set(i, expected_value)
@@ -67,76 +60,67 @@ class TestDigitalIO(unittest.TestCase):
             actual_value = self.digital_io.fetch(i)
             self.assertEqual(actual_value, not expected_value, f"Digital pin {i} invert expected {not expected_value} but got {actual_value}")
 
-    @patch('pokeys_py.digital_io.pokeyslib')
-    def test_setup_invalid_pin(self, mock_pokeyslib):
-        mock_pokeyslib.PK_SL_SetPinFunction.side_effect = ValueError("Invalid pin")
+    def test_setup_invalid_pin(self):
+        self.lib.PK_SL_SetPinFunction.side_effect = ValueError("Invalid pin")
         with self.assertRaises(ValueError):
             self.digital_io.setup(99, 'input')
 
-    @patch('pokeys_py.digital_io.pokeyslib')
-    def test_fetch_invalid_pin(self, mock_pokeyslib):
-        mock_pokeyslib.PK_SL_DigitalInputGet.side_effect = ValueError("Invalid pin")
+    def test_fetch_invalid_pin(self):
+        self.lib.PK_SL_DigitalInputGet.side_effect = ValueError("Invalid pin")
         with self.assertRaises(ValueError):
             self.digital_io.fetch(99)
 
-    @patch('pokeys_py.digital_io.pokeyslib')
-    def test_set_invalid_pin(self, mock_pokeyslib):
-        mock_pokeyslib.PK_SL_DigitalOutputSet.side_effect = ValueError("Invalid pin")
+    def test_set_invalid_pin(self):
+        self.lib.PK_SL_DigitalOutputSet.side_effect = ValueError("Invalid pin")
         with self.assertRaises(ValueError):
             self.digital_io.set(99, 0)
 
-    @patch('pokeys_py.digital_io.pokeyslib')
-    def test_hal_pins_mapped_to_signals(self, mock_pokeyslib):
+    def test_hal_pins_mapped_to_signals(self):
         # Ensure HAL pins are created and mapped to signals in tests/linuxcnc_config.hal
         self.digital_io.setup(0, 'input')
         self.digital_io.set(0, 1)
-        mock_pokeyslib.PK_SL_DigitalOutputSet.assert_called_with(self.device, 0, 1)
+        self.lib.PK_SL_DigitalOutputSet.assert_called_with(self.device, 0, 1)
         self.digital_io.set(0, 0)
-        mock_pokeyslib.PK_SL_DigitalOutputSet.assert_called_with(self.device, 0, 0)
+        self.lib.PK_SL_DigitalOutputSet.assert_called_with(self.device, 0, 0)
         self.digital_io.setup(0, 'output')
         self.digital_io.set(0, 1)
-        mock_pokeyslib.PK_SL_DigitalOutputSet.assert_called_with(self.device, 0, 1)
+        self.lib.PK_SL_DigitalOutputSet.assert_called_with(self.device, 0, 1)
         self.digital_io.set(0, 0)
-        mock_pokeyslib.PK_SL_DigitalOutputSet.assert_called_with(self.device, 0, 0)
+        self.lib.PK_SL_DigitalOutputSet.assert_called_with(self.device, 0, 0)
 
-    @patch('pokeys_py.digital_io.pokeyslib')
-    def test_setup_digin(self, mock_pokeyslib):
+    def test_setup_digin(self):
         self.digital_io.setup_digin(0, 1)
-        mock_pokeyslib.PK_HAL_SetPin.assert_any_call("pokeys.0.digin.1.in", mock_pokeyslib.PK_SL_DigitalInputGet.return_value)
-        mock_pokeyslib.PK_HAL_SetPin.assert_any_call("pokeys.0.digin.1.in-not", not mock_pokeyslib.PK_SL_DigitalInputGet.return_value)
+        self.lib.PK_HAL_SetPin.assert_any_call("pokeys.0.digin.1.in", self.lib.PK_SL_DigitalInputGet.return_value)
+        self.lib.PK_HAL_SetPin.assert_any_call("pokeys.0.digin.1.in-not", not self.lib.PK_SL_DigitalInputGet.return_value)
 
-    @patch('pokeys_py.digital_io.pokeyslib')
-    def test_setup_digout(self, mock_pokeyslib):
+    def test_setup_digout(self):
         self.digital_io.setup_digout(0, 1)
-        mock_pokeyslib.PK_HAL_SetPin.assert_any_call("pokeys.0.digout.1.out", mock_pokeyslib.PK_SL_DigitalInputGet.return_value)
-        mock_pokeyslib.PK_HAL_SetPin.assert_any_call("pokeys.0.digout.1.out-not", not mock_pokeyslib.PK_SL_DigitalInputGet.return_value)
+        self.lib.PK_HAL_SetPin.assert_any_call("pokeys.0.digout.1.out", self.lib.PK_SL_DigitalInputGet.return_value)
+        self.lib.PK_HAL_SetPin.assert_any_call("pokeys.0.digout.1.out-not", not self.lib.PK_SL_DigitalInputGet.return_value)
 
-    @patch('pokeys_py.digital_io.pokeyslib')
-    def test_digital_io_parameters(self, mock_pokeyslib):
+    def test_digital_io_parameters(self):
         self.digital_io.setup(1, 'input')
         self.digital_io.set(1, 1)
-        mock_pokeyslib.PK_SL_DigitalOutputSet.assert_called_with(self.device, 1, 1)
+        self.lib.PK_SL_DigitalOutputSet.assert_called_with(self.device, 1, 1)
         self.digital_io.set(1, 0)
-        mock_pokeyslib.PK_SL_DigitalOutputSet.assert_called_with(self.device, 1, 0)
+        self.lib.PK_SL_DigitalOutputSet.assert_called_with(self.device, 1, 0)
         self.digital_io.setup(1, 'output')
         self.digital_io.set(1, 1)
-        mock_pokeyslib.PK_SL_DigitalOutputSet.assert_called_with(self.device, 1, 1)
+        self.lib.PK_SL_DigitalOutputSet.assert_called_with(self.device, 1, 1)
         self.digital_io.set(1, 0)
-        mock_pokeyslib.PK_SL_DigitalOutputSet.assert_called_with(self.device, 1, 0)
+        self.lib.PK_SL_DigitalOutputSet.assert_called_with(self.device, 1, 0)
 
-    @patch('pokeys_py.digital_io.pokeyslib')
-    def test_digital_input_hal_interface(self, mock_pokeyslib):
+    def test_digital_input_hal_interface(self):
         for pin_id in range(55):
             self.digital_io.setup_digin(0, pin_id)
-            mock_pokeyslib.PK_HAL_SetPin.assert_any_call(f"pokeys.0.digin.{pin_id}.in", mock_pokeyslib.PK_SL_DigitalInputGet.return_value)
-            mock_pokeyslib.PK_HAL_SetPin.assert_any_call(f"pokeys.0.digin.{pin_id}.in-not", not mock_pokeyslib.PK_SL_DigitalInputGet.return_value)
+            self.lib.PK_HAL_SetPin.assert_any_call(f"pokeys.0.digin.{pin_id}.in", self.lib.PK_SL_DigitalInputGet.return_value)
+            self.lib.PK_HAL_SetPin.assert_any_call(f"pokeys.0.digin.{pin_id}.in-not", not self.lib.PK_SL_DigitalInputGet.return_value)
 
-    @patch('pokeys_py.digital_io.pokeyslib')
-    def test_digital_output_hal_interface(self, mock_pokeyslib):
+    def test_digital_output_hal_interface(self):
         for pin_id in range(55):
             self.digital_io.setup_digout(0, pin_id)
-            mock_pokeyslib.PK_HAL_SetPin.assert_any_call(f"pokeys.0.digout.{pin_id}.out", mock_pokeyslib.PK_SL_DigitalInputGet.return_value)
-            mock_pokeyslib.PK_HAL_SetPin.assert_any_call(f"pokeys.0.digout.{pin_id}.out-not", not mock_pokeyslib.PK_SL_DigitalInputGet.return_value)
+            self.lib.PK_HAL_SetPin.assert_any_call(f"pokeys.0.digout.{pin_id}.out", self.lib.PK_SL_DigitalInputGet.return_value)
+            self.lib.PK_HAL_SetPin.assert_any_call(f"pokeys.0.digout.{pin_id}.out-not", not self.lib.PK_SL_DigitalInputGet.return_value)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -1,11 +1,12 @@
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 from pokeys_py.pev2_motion_control import PEv2MotionControl
 
 class TestFunctionalPEv2MotionControl(unittest.TestCase):
     def setUp(self):
         self.device = MagicMock()
-        self.pev2 = PEv2MotionControl(self.device)
+        self.lib = MagicMock()
+        self.pev2 = PEv2MotionControl(self.device, self.lib)
 
     def test_motion_control_sequences(self):
         # Test starting motion control

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,34 +1,29 @@
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 from pokeys_py import digital_io, analog_io, pwm, counter, ponet, pev2_motion_control
 
 class TestIntegrationPokeysPy(unittest.TestCase):
 
-    @patch('pokeys_py.digital_io.pokeyslib')
-    @patch('pokeys_py.analog_io.pokeyslib')
-    @patch('pokeys_py.pwm.pokeyslib')
-    @patch('pokeys_py.counter.pokeyslib')
-    @patch('pokeys_py.ponet.pokeyslib')
-    @patch('pokeys_py.pev2_motion_control.pokeyslib')
-    def setUp(self, mock_pev2, mock_ponet, mock_counter, mock_pwm, mock_analog, mock_digital):
+    def setUp(self):
         self.device = MagicMock()
-        self.digital_io = digital_io.DigitalIO(self.device)
-        self.analog_io = analog_io.AnalogIO(self.device)
-        self.pwm = pwm.PWM(self.device)
-        self.counter = counter.Counter(self.device)
-        self.ponet = ponet.PoNET(self.device)
-        self.pev2 = pev2_motion_control.PEv2MotionControl(self.device)
+        self.lib = MagicMock()
+        self.digital_io = digital_io.DigitalIO(self.device, self.lib)
+        self.analog_io = analog_io.AnalogIO(self.device, self.lib)
+        self.pwm = pwm.PWM(self.device, self.lib)
+        self.counter = counter.Counter(self.device, self.lib)
+        self.ponet = ponet.PoNET(self.device, self.lib)
+        self.pev2 = pev2_motion_control.PEv2MotionControl(self.device, self.lib)
 
     def test_initialization_and_connection(self):
-        self.device.PK_ConnectToDevice.assert_called_once()
+        self.lib.PK_ConnectToDevice.assert_called_once()
 
     def test_data_exchange(self):
         self.digital_io.setup(1, 'input')
         self.digital_io.fetch(1)
         self.digital_io.set(1, 1)
-        self.device.PK_SL_SetPinFunction.assert_called_with(self.device, 1, 2)
-        self.device.PK_SL_DigitalInputGet.assert_called_with(self.device, 1)
-        self.device.PK_SL_DigitalOutputSet.assert_called_with(self.device, 1, 1)
+        self.lib.PK_SL_SetPinFunction.assert_called_with(self.device, 1, 2)
+        self.lib.PK_SL_DigitalInputGet.assert_called_with(self.device, 1)
+        self.lib.PK_SL_DigitalOutputSet.assert_called_with(self.device, 1, 1)
 
     def test_registration_and_communication_with_hal(self):
         self.pev2.setup(1, {'param': 'value'})
@@ -38,14 +33,14 @@ class TestIntegrationPokeysPy(unittest.TestCase):
         self.pev2.start_homing(1)
         self.pev2.cancel_homing(1)
         self.pev2.get_homing_status(1)
-        self.device.PK_PEv2_AxisConfigurationSet.assert_called_with(self.device, 1, {'param': 'value'})
-        self.device.PK_PEv2_StatusGet.assert_called_with(self.device)
-        self.device.PK_PEv2_GetPosition.assert_called_with(self.device)
-        self.device.PK_PEv2_SetPosition.assert_called_with(self.device, 1, 100)
-        self.device.PK_PEv2_SetVelocity.assert_called_with(self.device, 1, 50)
-        self.device.PK_PEv2_StartHoming.assert_called_with(self.device, 1)
-        self.device.PK_PEv2_CancelHoming.assert_called_with(self.device, 1)
-        self.device.PK_PEv2_GetHomingStatus.assert_called_with(self.device, 1)
+        self.lib.PK_PEv2_AxisConfigurationSet.assert_called_with(self.device, 1, {'param': 'value'})
+        self.lib.PK_PEv2_StatusGet.assert_called_with(self.device)
+        self.lib.PK_PEv2_GetPosition.assert_called_with(self.device)
+        self.lib.PK_PEv2_SetPosition.assert_called_with(self.device, 1, 100)
+        self.lib.PK_PEv2_SetVelocity.assert_called_with(self.device, 1, 50)
+        self.lib.PK_PEv2_StartHoming.assert_called_with(self.device, 1)
+        self.lib.PK_PEv2_CancelHoming.assert_called_with(self.device, 1)
+        self.lib.PK_PEv2_GetHomingStatus.assert_called_with(self.device, 1)
 
     def test_error_conditions_and_edge_cases(self):
         # Test invalid pin for digital I/O
@@ -107,38 +102,38 @@ class TestIntegrationPokeysPy(unittest.TestCase):
         self.digital_io.setup(1, 'input')
         self.digital_io.fetch(1)
         self.digital_io.set(1, 1)
-        self.device.PK_SL_SetPinFunction.assert_called_with(self.device, 1, 2)
-        self.device.PK_SL_DigitalInputGet.assert_called_with(self.device, 1)
-        self.device.PK_SL_DigitalOutputSet.assert_called_with(self.device, 1, 1)
+        self.lib.PK_SL_SetPinFunction.assert_called_with(self.device, 1, 2)
+        self.lib.PK_SL_DigitalInputGet.assert_called_with(self.device, 1)
+        self.lib.PK_SL_DigitalOutputSet.assert_called_with(self.device, 1, 1)
 
         self.analog_io.setup(1, 'input')
         self.analog_io.fetch(1)
         self.analog_io.set(1, 1.0)
-        self.device.PK_SL_SetPinFunction.assert_called_with(self.device, 1, 1)
-        self.device.PK_SL_AnalogInputGet.assert_called_with(self.device, 1)
-        self.device.PK_SL_AnalogOutputSet.assert_called_with(self.device, 1, 1.0)
+        self.lib.PK_SL_SetPinFunction.assert_called_with(self.device, 1, 1)
+        self.lib.PK_SL_AnalogInputGet.assert_called_with(self.device, 1)
+        self.lib.PK_SL_AnalogOutputSet.assert_called_with(self.device, 1, 1.0)
 
         self.pwm.setup(1, 1000, 50)
         self.pwm.fetch(1)
         self.pwm.set(1, 1000, 50)
-        self.device.PK_PWM_Setup.assert_called_with(self.device, 1, 1000, 50)
-        self.device.PK_PWM_Fetch.assert_called_with(self.device, 1, unittest.mock.ANY, unittest.mock.ANY)
-        self.device.PK_PWM_Set.assert_called_with(self.device, 1, 1000, 50)
+        self.lib.PK_PWM_Setup.assert_called_with(self.device, 1, 1000, 50)
+        self.lib.PK_PWM_Fetch.assert_called_with(self.device, 1, unittest.mock.ANY, unittest.mock.ANY)
+        self.lib.PK_PWM_Set.assert_called_with(self.device, 1, 1000, 50)
 
         self.counter.setup(1)
         self.counter.fetch(1)
         self.counter.clear(1)
-        self.device.PK_IsCounterAvailable.assert_called_with(self.device, 1)
-        self.device.PK_DigitalCounterGet.assert_called_with(self.device)
-        self.device.PK_DigitalCounterClear.assert_called_with(self.device)
+        self.lib.PK_IsCounterAvailable.assert_called_with(self.device, 1)
+        self.lib.PK_DigitalCounterGet.assert_called_with(self.device)
+        self.lib.PK_DigitalCounterClear.assert_called_with(self.device)
 
         self.ponet.setup(1)
         self.ponet.fetch(1)
         self.ponet.set(1, 'data')
-        self.device.PK_PoNETGetModuleSettings.assert_called_with(self.device, 1)
-        self.device.PK_PoNETGetModuleStatusRequest.assert_called_with(self.device, 1)
-        self.device.PK_PoNETGetModuleStatus.assert_called_with(self.device, 1)
-        self.device.PK_PoNETSetModuleStatus.assert_called_with(self.device, 1, 'data')
+        self.lib.PK_PoNETGetModuleSettings.assert_called_with(self.device, 1)
+        self.lib.PK_PoNETGetModuleStatusRequest.assert_called_with(self.device, 1)
+        self.lib.PK_PoNETGetModuleStatus.assert_called_with(self.device, 1)
+        self.lib.PK_PoNETSetModuleStatus.assert_called_with(self.device, 1, 'data')
 
         self.pev2.setup(1, {'param': 'value'})
         self.pev2.fetch_status()
@@ -147,14 +142,14 @@ class TestIntegrationPokeysPy(unittest.TestCase):
         self.pev2.start_homing(1)
         self.pev2.cancel_homing(1)
         self.pev2.get_homing_status(1)
-        self.device.PK_PEv2_AxisConfigurationSet.assert_called_with(self.device, 1, {'param': 'value'})
-        self.device.PK_PEv2_StatusGet.assert_called_with(self.device)
-        self.device.PK_PEv2_GetPosition.assert_called_with(self.device)
-        self.device.PK_PEv2_SetPosition.assert_called_with(self.device, 1, 100)
-        self.device.PK_PEv2_SetVelocity.assert_called_with(self.device, 1, 50)
-        self.device.PK_PEv2_StartHoming.assert_called_with(self.device, 1)
-        self.device.PK_PEv2_CancelHoming.assert_called_with(self.device, 1)
-        self.device.PK_PEv2_GetHomingStatus.assert_called_with(self.device, 1)
+        self.lib.PK_PEv2_AxisConfigurationSet.assert_called_with(self.device, 1, {'param': 'value'})
+        self.lib.PK_PEv2_StatusGet.assert_called_with(self.device)
+        self.lib.PK_PEv2_GetPosition.assert_called_with(self.device)
+        self.lib.PK_PEv2_SetPosition.assert_called_with(self.device, 1, 100)
+        self.lib.PK_PEv2_SetVelocity.assert_called_with(self.device, 1, 50)
+        self.lib.PK_PEv2_StartHoming.assert_called_with(self.device, 1)
+        self.lib.PK_PEv2_CancelHoming.assert_called_with(self.device, 1)
+        self.lib.PK_PEv2_GetHomingStatus.assert_called_with(self.device, 1)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -1,14 +1,14 @@
 import time
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 from pokeys_py import digital_io, analog_io, pwm, counter, ponet, pev2_motion_control
 
 class TestPerformance(unittest.TestCase):
 
-    @patch('pokeys_py.digital_io.pokeyslib')
-    def test_digital_io_performance(self, mock_pokeyslib):
+    def test_digital_io_performance(self):
         device = MagicMock()
-        dio = digital_io.DigitalIO(device)
+        lib = MagicMock()
+        dio = digital_io.DigitalIO(device, lib)
         start_time = time.time()
         for _ in range(1000):
             dio.set(1, 1)
@@ -17,10 +17,10 @@ class TestPerformance(unittest.TestCase):
         latency = (end_time - start_time) / 1000
         self.assertLess(latency, 0.001, "Digital IO latency is too high")
 
-    @patch('pokeys_py.analog_io.pokeyslib')
-    def test_analog_io_performance(self, mock_pokeyslib):
+    def test_analog_io_performance(self):
         device = MagicMock()
-        aio = analog_io.AnalogIO(device)
+        lib = MagicMock()
+        aio = analog_io.AnalogIO(device, lib)
         start_time = time.time()
         for _ in range(1000):
             aio.set(1, 1.0)
@@ -29,10 +29,10 @@ class TestPerformance(unittest.TestCase):
         latency = (end_time - start_time) / 1000
         self.assertLess(latency, 0.001, "Analog IO latency is too high")
 
-    @patch('pokeys_py.pwm.pokeyslib')
-    def test_pwm_performance(self, mock_pokeyslib):
+    def test_pwm_performance(self):
         device = MagicMock()
-        pwm_io = pwm.PWM(device)
+        lib = MagicMock()
+        pwm_io = pwm.PWM(device, lib)
         start_time = time.time()
         for _ in range(1000):
             pwm_io.set(1, 1000, 50)
@@ -41,10 +41,10 @@ class TestPerformance(unittest.TestCase):
         latency = (end_time - start_time) / 1000
         self.assertLess(latency, 0.001, "PWM latency is too high")
 
-    @patch('pokeys_py.counter.pokeyslib')
-    def test_counter_performance(self, mock_pokeyslib):
+    def test_counter_performance(self):
         device = MagicMock()
-        counter_io = counter.Counter(device)
+        lib = MagicMock()
+        counter_io = counter.Counter(device, lib)
         start_time = time.time()
         for _ in range(1000):
             counter_io.clear(1)
@@ -53,10 +53,10 @@ class TestPerformance(unittest.TestCase):
         latency = (end_time - start_time) / 1000
         self.assertLess(latency, 0.001, "Counter latency is too high")
 
-    @patch('pokeys_py.ponet.pokeyslib')
-    def test_ponet_performance(self, mock_pokeyslib):
+    def test_ponet_performance(self):
         device = MagicMock()
-        ponet_io = ponet.PoNET(device)
+        lib = MagicMock()
+        ponet_io = ponet.PoNET(device, lib)
         start_time = time.time()
         for _ in range(1000):
             ponet_io.set(1, 1)
@@ -65,10 +65,10 @@ class TestPerformance(unittest.TestCase):
         latency = (end_time - start_time) / 1000
         self.assertLess(latency, 0.001, "PoNET latency is too high")
 
-    @patch('pokeys_py.pev2_motion_control.pokeyslib')
-    def test_pev2_motion_control_performance(self, mock_pokeyslib):
+    def test_pev2_motion_control_performance(self):
         device = MagicMock()
-        pev2_io = pev2_motion_control.PEv2MotionControl(device)
+        lib = MagicMock()
+        pev2_io = pev2_motion_control.PEv2MotionControl(device, lib)
         start_time = time.time()
         for _ in range(1000):
             pev2_io.set_position(1, 1000)
@@ -77,69 +77,69 @@ class TestPerformance(unittest.TestCase):
         latency = (end_time - start_time) / 1000
         self.assertLess(latency, 0.001, "PEv2 Motion Control latency is too high")
 
-    @patch('pokeys_py.digital_io.pokeyslib')
-    def test_digital_io_error_conditions(self, mock_pokeyslib):
+    def test_digital_io_error_conditions(self):
         device = MagicMock()
-        dio = digital_io.DigitalIO(device)
+        lib = MagicMock()
+        dio = digital_io.DigitalIO(device, lib)
         with self.assertRaises(ValueError):
             dio.set(99, 1)
         with self.assertRaises(ValueError):
             dio.fetch(99)
 
-    @patch('pokeys_py.analog_io.pokeyslib')
-    def test_analog_io_error_conditions(self, mock_pokeyslib):
+    def test_analog_io_error_conditions(self):
         device = MagicMock()
-        aio = analog_io.AnalogIO(device)
+        lib = MagicMock()
+        aio = analog_io.AnalogIO(device, lib)
         with self.assertRaises(ValueError):
             aio.set(99, 1.0)
         with self.assertRaises(ValueError):
             aio.fetch(99)
 
-    @patch('pokeys_py.pwm.pokeyslib')
-    def test_pwm_error_conditions(self, mock_pokeyslib):
+    def test_pwm_error_conditions(self):
         device = MagicMock()
-        pwm_io = pwm.PWM(device)
+        lib = MagicMock()
+        pwm_io = pwm.PWM(device, lib)
         with self.assertRaises(ValueError):
             pwm_io.set(99, 1000, 50)
         with self.assertRaises(ValueError):
             pwm_io.fetch(99)
 
-    @patch('pokeys_py.counter.pokeyslib')
-    def test_counter_error_conditions(self, mock_pokeyslib):
+    def test_counter_error_conditions(self):
         device = MagicMock()
-        counter_io = counter.Counter(device)
+        lib = MagicMock()
+        counter_io = counter.Counter(device, lib)
         with self.assertRaises(ValueError):
             counter_io.clear(99)
         with self.assertRaises(ValueError):
             counter_io.fetch(99)
 
-    @patch('pokeys_py.ponet.pokeyslib')
-    def test_ponet_error_conditions(self, mock_pokeyslib):
+    def test_ponet_error_conditions(self):
         device = MagicMock()
-        ponet_io = ponet.PoNET(device)
+        lib = MagicMock()
+        ponet_io = ponet.PoNET(device, lib)
         with self.assertRaises(ValueError):
             ponet_io.set(99, 1)
         with self.assertRaises(ValueError):
             ponet_io.fetch(99)
 
-    @patch('pokeys_py.pev2_motion_control.pokeyslib')
-    def test_pev2_motion_control_error_conditions(self, mock_pokeyslib):
+    def test_pev2_motion_control_error_conditions(self):
         device = MagicMock()
-        pev2_io = pev2_motion_control.PEv2MotionControl(device)
+        lib = MagicMock()
+        pev2_io = pev2_motion_control.PEv2MotionControl(device, lib)
         with self.assertRaises(ValueError):
             pev2_io.set_position(99, 1000)
         with self.assertRaises(ValueError):
             pev2_io.fetch_status()
 
-    @patch('pokeys_py.pokeyslib')
-    def test_performance_under_load(self, mock_pokeyslib):
+    def test_performance_under_load(self):
         device = MagicMock()
-        dio = digital_io.DigitalIO(device)
-        aio = analog_io.AnalogIO(device)
-        pwm_io = pwm.PWM(device)
-        counter_io = counter.Counter(device)
-        ponet_io = ponet.PoNET(device)
-        pev2_io = pev2_motion_control.PEv2MotionControl(device)
+        lib = MagicMock()
+        dio = digital_io.DigitalIO(device, lib)
+        aio = analog_io.AnalogIO(device, lib)
+        pwm_io = pwm.PWM(device, lib)
+        counter_io = counter.Counter(device, lib)
+        ponet_io = ponet.PoNET(device, lib)
+        pev2_io = pev2_motion_control.PEv2MotionControl(device, lib)
 
         start_time = time.time()
         for _ in range(1000):


### PR DESCRIPTION
## Summary
- add simple CANBus wrapper
- inject pokeyslib mock in PoNET
- configure telemetry for CI and add missing test mock
- refactor tests to create MagicMock libraries instead of using `patch`

## Testing
- `pip install -q -r requirements-dev.txt`
- `pytest -q` *(fails: ModuleNotFoundError and KeyError)*

------
https://chatgpt.com/codex/tasks/task_e_6853d7d005bc8322b1e5df3c8d33796d