### PR TITLE
Refactor pokeys_py initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,18 @@ cd LinuxCnc_PokeysLibComp
 sudo sh install.sh
 ```
 
+## Running the UI Setup Tool
+
+After installation you can launch the graphical configuration utility with:
+
+```bash
+python -m pokeys_py
+```
+
+Importing the ``pokeys_py`` package no longer performs any device actions or
+telemetry initialization. Hardware is only accessed when the setup tool or
+``run_ui_setup_tool`` function is invoked.
+
 ## Hardware Requirements
 
 The project has been tested with the following hardware:

--- a/pokeys_py/__main__.py
+++ b/pokeys_py/__main__.py
@@ -1,9 +1,12 @@
 """Command line interface for pokeys_py."""
 
 
+from . import run_ui_setup_tool
+
+
 def main() -> None:
     """Entry point for the console script."""
-    print("PoKeys Python library command-line interface")
+    run_ui_setup_tool()
 
 
 if __name__ == "__main__":

--- a/pokeys_py/porelay8.py
+++ b/pokeys_py/porelay8.py
@@ -1,0 +1,16 @@
+from . import pokeyslib
+
+class PoRelay8:
+    def __init__(self, device, lib=None):
+        self.device = device
+        self.lib = lib or pokeyslib
+
+    def setup(self, module_id):
+        return self.lib.PK_PoRelay8_GetModuleSettings(self.device, module_id)
+
+    def fetch(self, module_id):
+        self.lib.PK_PoRelay8_GetModuleStatusRequest(self.device, module_id)
+        return self.lib.PK_PoRelay8_GetModuleStatus(self.device, module_id)
+
+    def set(self, module_id, data):
+        self.lib.PK_PoRelay8_SetModuleStatus(self.device, module_id, data)

--- a/pokeys_py/ui_setup_tool.py
+++ b/pokeys_py/ui_setup_tool.py
@@ -3,10 +3,13 @@ import ctypes
 from .telemetry import Telemetry
 
 class UISetupTool:
-    def __init__(self):
+    def __init__(self, opt_in=False):
         self.pokeyslib = ctypes.CDLL('/usr/lib/linuxcnc/modules/PoKeysLib.so')
         self.device = None
-        self.telemetry = Telemetry(dsn="your_sentry_dsn_here", opt_in=True)
+        if os.getenv('CI') == 'true':
+            self.telemetry = Telemetry(dsn="", opt_in=False)
+        else:
+            self.telemetry = Telemetry(dsn="your_sentry_dsn_here", opt_in=opt_in)
         self.telemetry.initialize_sentry()
 
     def connect_device(self, device_index):


### PR DESCRIPTION
## Summary
- prevent hardware and telemetry init on import
- move device setup & UI launch into `run_ui_setup_tool`
- call new initializer from `__main__`
- allow running the setup tool via `python -m pokeys_py`
- avoid telemetry during tests
- stub PoRelay8 module

## Testing
- `pip install -e .`
- `pytest tests/test_ui_setup_tool.py::TestUISetupTool::test_connect_device -q`
- `pytest -q` *(fails: 110 failed, 105 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6853f53287648322be74e1a42d4ea6d9