### PR TITLE
Add sentry-sdk dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,9 @@ setup(
     name='pokeys_py',
     version='0.1.0',
     packages=find_packages(),
-    install_requires=[],
+    install_requires=[
+        'sentry-sdk',
+    ],
     extras_require={
         'dev': ['pytest'],
     },


### PR DESCRIPTION
## Summary
- depend on sentry-sdk in setup.py

## Testing
- `python3 -m pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685405b6869c832297bd35c808088ceb